### PR TITLE
API URI 수정 및 불필요 주석 삭제

### DIFF
--- a/src/main/java/com/mjuAppSW/joA/domain/heart/HeartService.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/heart/HeartService.java
@@ -37,11 +37,6 @@ public class HeartService {
 
         Heart newHeart = createHeart(giveMemberId, takeMember);
         heartRepository.save(newHeart);
-        /**
-         * if(채팅방이 이미 존재) {
-         *      채팅방이 이미 존재합니다! 예외!
-         * }
-         */
         checkExistedRoom(giveMember, takeMember);
 
         boolean isMatched = isOpponentHeartExisted(takeMemberId, giveMemberId);

--- a/src/main/java/com/mjuAppSW/joA/geography/location/LocationApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/geography/location/LocationApiController.java
@@ -58,7 +58,7 @@ public class LocationApiController {
             @ApiResponse(responseCode = "404-2", description = "L001: 사용자의 위치 정보를 찾을 수 없습니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "409", description = "P002: 사용자가 학교 밖에 위치합니다.", content = @Content(schema = @Schema(hidden = true)))
     })
-    @GetMapping("/{id}/near-by-list")
+    @GetMapping("/{id}")
     public ResponseEntity<SuccessResponse<NearByListResponse>> getNearByList(
             @Parameter(description = "사용자 세션 id", in = ParameterIn.PATH) @PathVariable("id") @NotNull Long sessionId,
             @Parameter(description = "사용자 현재 위도", in = ParameterIn.QUERY) @RequestParam @NotBlank Double latitude,


### PR DESCRIPTION
# 요약
- 주변 사람 목록 조회 API의 URI를 간략화 하였습니다.
- 하트 전송 API에서 테스트 요청을 위해 남겨뒀던 주석을 (테스트 완료 이후) 제거하였습니다.

# 체크 리스트
이 PR에는:

- [ ] 새로운 테스트의 추가 여부
- [x] 공개 API의 변경 여부
- [ ] 설계 문서의 포함 여부

# 본문
주변 사람 목록 조회 API의 URI처럼 'location/{id}'만으로는 내 위치 조회(물론 없는 API이지만)의 의미를 나타낼 수도 있을 듯 해요.
하지만 현재 그러한 기능이 존재하지 않고,
location 리소스의 API가 두 가지만 존재하는 상황에서 {id} 이후에 설명을 덧붙이는 건 불필요하단 생각이 들어 
부가 설명을 삭제하였습니다.
사실 해당 API 뿐만 아니라 여러 군데에서 동일한 고민이 들었는데요.
어떤게 좋은 URI 작성법인지 잘 모르겠습니다!

URI만으로 API가 어떤 기능을 나타내는지 파악 가능해야 할까요?
아니면
URI는 간략하게 작성하여 최소한으로 필요한 리소스만 포함하고 있어야 할까요?
