### PR TITLE
API URI 수정, Swagger 그룹명 변경 및 주석처리 삭제

### DIFF
--- a/src/main/java/com/mjuAppSW/joA/common/config/SwaggerConfig.java
+++ b/src/main/java/com/mjuAppSW/joA/common/config/SwaggerConfig.java
@@ -116,14 +116,13 @@ public class SwaggerConfig {
                 .build();
     }
 
-    // 임의 지정, 변경 요함
     @Bean
     public GroupedOpenApi messageOpenApi() {
         String[] paths = {"/joa/messages/**"};
 
         return GroupedOpenApi
                 .builder()
-                .group("채팅 API")
+                .group("채팅 메시지 API")
                 .pathsToMatch(paths)
                 .build();
     }
@@ -134,7 +133,7 @@ public class SwaggerConfig {
 
         return GroupedOpenApi
                 .builder()
-                .group("채팅방 API")
+                .group("방 API")
                 .pathsToMatch(paths)
                 .build();
     }
@@ -145,9 +144,8 @@ public class SwaggerConfig {
 
         return GroupedOpenApi
                 .builder()
-                .group("채팅 사용자 API")
+                .group("채팅방 API")
                 .pathsToMatch(paths)
                 .build();
     }
-
 }

--- a/src/main/java/com/mjuAppSW/joA/common/exception/ErrorCode.java
+++ b/src/main/java/com/mjuAppSW/joA/common/exception/ErrorCode.java
@@ -57,7 +57,7 @@ public enum ErrorCode {
     ROOM_EXISTED(409, "R001", "이미 채팅방이 존재합니다."),
     OVER_ONE_DAY(400, "R002", "방이 생성된지 24시간이 지났습니다."),
     ROOM_NOT_FOUND(404, "R003", "방을 찾을 수 없습니다."),
-    ROOM_ALREADY_EXTEND(409, "R004", "이미 연장된 채팅방입니다."),
+    ROOM_ALREADY_EXTEND(409, "R004", "이미 연장된 방입니다."),
 
     // RoomInMember
     RIM_NOT_FOUND(404, "RIM001", "채팅방을 찾을 수 없습니다."),

--- a/src/main/java/com/mjuAppSW/joA/domain/member/MemberApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/member/MemberApiController.java
@@ -126,8 +126,8 @@ public class MemberApiController {
             @ApiResponse(responseCode = "404-2", description = "M001: 사용자를 찾을 수 없습니다.", content = @Content(schema = @Schema(hidden = true))),
     })
     @GetMapping("/id/find")
-    public ResponseEntity<Void> findId(@RequestBody @Valid FindIdRequest request) {
-        memberService.findId(request);
+    public ResponseEntity<Void> findId(@RequestParam("collegeEmail") String collegeEmail, @RequestParam("collegeId") Long collegeId) {
+        memberService.findId(collegeEmail, collegeId);
         return ResponseEntity.ok().build();
     }
 
@@ -137,8 +137,8 @@ public class MemberApiController {
             @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다.", content = @Content(schema = @Schema(hidden = true))),
     })
     @GetMapping("/password/find")
-    public ResponseEntity<Void> findPassword(@RequestBody @Valid FindPasswordRequest request) {
-        memberService.findPassword(request);
+    public ResponseEntity<Void> findPassword(@RequestParam("loginId") String loginId) {
+        memberService.findPassword(loginId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/mjuAppSW/joA/domain/member/MemberService.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/member/MemberService.java
@@ -291,18 +291,18 @@ public class MemberService {
         findMember.expireSessionId();
     }
 
-    public void findId(FindIdRequest request) {
-        MCollege college = findByMCollegeId(request.getCollegeId());
+    public void findId(String collegeEmail, Long collegeId) {
+        MCollege college = findByMCollegeId(collegeId);
 
-        Member member = memberRepository.findByuEmailAndcollege(request.getCollegeEmail(), college)
+        Member member = memberRepository.findByuEmailAndcollege(collegeEmail, college)
                 .orElseThrow(MemberNotFoundException::new);
 
         mail(USER_ID_IS, member.getName(), member.getUEmail(), college.getDomain(), member.getLoginId());
     }
 
     @Transactional
-    public void findPassword(FindPasswordRequest request) {
-        Member member = memberChecker.findByLoginId(request.getLoginId());
+    public void findPassword(String loginId) {
+        Member member = memberChecker.findByLoginId(loginId);
 
         String randomPassword = randomPassword();
         String hashedRandomPassword = BCrypt.hashpw(randomPassword, member.getSalt());

--- a/src/main/java/com/mjuAppSW/joA/domain/memberProfile/MemberProfileApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/memberProfile/MemberProfileApiController.java
@@ -7,6 +7,8 @@ import com.mjuAppSW.joA.domain.memberProfile.dto.request.PictureRequest;
 import com.mjuAppSW.joA.domain.memberProfile.dto.response.SettingPageResponse;
 import com.mjuAppSW.joA.domain.memberProfile.dto.response.VotePageResponse;
 import com.mjuAppSW.joA.domain.memberProfile.dto.response.LocationPageResponse;
+import com.mjuAppSW.joA.domain.memberProfile.dto.response.UserInfoResponse;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -148,5 +150,18 @@ public class MemberProfileApiController {
             @Parameter(description = "사용자 세션 id", in = ParameterIn.PATH) @PathVariable("id") Long sessionId) {
         memberProfileService.deletePicture(sessionId);
         return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "채팅방 입장시 상대방 정보 조회", description = "상대방 정보 조회 API")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "상대방 정보 반환"),
+        @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다."),
+        @ApiResponse(responseCode = "404", description = "R003: 방을 찾을 수 없습니다."),
+        @ApiResponse(responseCode = "404", description = "RIM001: 채팅방을 찾을 수 없습니다.")
+    })
+    @GetMapping("/{roomId}/{memberId}/userinfo")
+    public ResponseEntity<SuccessResponse<UserInfoResponse>> getUserInfo(@PathVariable("roomId") Long roomId, @PathVariable("memberId") Long memberId){
+        return SuccessResponse.of(memberProfileService.getUserInfo(roomId, memberId))
+            .asHttp(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/memberProfile/MemberProfileService.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/memberProfile/MemberProfileService.java
@@ -10,7 +10,16 @@ import com.mjuAppSW.joA.domain.memberProfile.dto.request.BioRequest;
 import com.mjuAppSW.joA.domain.memberProfile.dto.response.MyPageResponse;
 import com.mjuAppSW.joA.domain.memberProfile.dto.request.PictureRequest;
 import com.mjuAppSW.joA.domain.memberProfile.dto.response.SettingPageResponse;
+import com.mjuAppSW.joA.domain.memberProfile.dto.response.UserInfoResponse;
 import com.mjuAppSW.joA.domain.memberProfile.exception.InvalidS3Exception;
+import com.mjuAppSW.joA.domain.room.Room;
+import com.mjuAppSW.joA.domain.room.RoomRepository;
+import com.mjuAppSW.joA.domain.room.exception.RoomNotFoundException;
+import com.mjuAppSW.joA.domain.roomInMember.RoomInMember;
+import com.mjuAppSW.joA.domain.roomInMember.RoomInMemberRepository;
+import com.mjuAppSW.joA.domain.roomInMember.exception.RoomInMemberNotFoundException;
+
+import com.mjuAppSW.joA.domain.memberProfile.vo.UserInfoVO;
 import com.mjuAppSW.joA.domain.vote.VoteRepository;
 import com.mjuAppSW.joA.common.storage.S3Uploader;
 import com.mjuAppSW.joA.domain.memberProfile.dto.response.VotePageResponse;
@@ -27,6 +36,8 @@ public class MemberProfileService {
 
     private final HeartRepository heartRepository;
     private final VoteRepository voteRepository;
+    private final RoomRepository roomRepository;
+    private final RoomInMemberRepository roomInMemberRepository;
     private final MemberChecker memberChecker;
     private final S3Uploader s3Uploader;
 
@@ -51,6 +62,16 @@ public class MemberProfileService {
 
     public LocationPageResponse getLocationPage(Long sessionId) {
         return LocationPageResponse.of(memberChecker.findFilterBySessionId(sessionId));
+    }
+
+    public UserInfoResponse getUserInfo(Long roomId, Long memberId){
+        Room room = roomRepository.findById(roomId).orElseThrow(RoomNotFoundException::new);
+        Member member = memberChecker.findBySessionId(memberId);
+        RoomInMember roomInMember = roomInMemberRepository.findByRoomAndMember(room, member).orElseThrow(
+            RoomInMemberNotFoundException::new);
+
+        UserInfoVO userInfoVO = roomInMemberRepository.getUserInfo(roomInMember.getRoom(), roomInMember.getMember());
+        return UserInfoResponse.of(userInfoVO.getName(), userInfoVO.getUrlCode(), userInfoVO.getBio());
     }
 
     @Transactional

--- a/src/main/java/com/mjuAppSW/joA/domain/memberProfile/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/memberProfile/dto/response/UserInfoResponse.java
@@ -1,0 +1,25 @@
+package com.mjuAppSW.joA.domain.memberProfile.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@Schema(description = "채팅방 입장시 상대방 정보 조회 Response")
+@Builder(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserInfoResponse {
+	private final String name;
+	private final String urlCode;
+	private final String bio;
+
+	public static UserInfoResponse of(String name, String urlCode, String bio) {
+		return UserInfoResponse.builder()
+			.name(name)
+			.urlCode(urlCode)
+			.bio(bio)
+			.build();
+	}
+}

--- a/src/main/java/com/mjuAppSW/joA/domain/memberProfile/vo/UserInfoVO.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/memberProfile/vo/UserInfoVO.java
@@ -1,4 +1,4 @@
-package com.mjuAppSW.joA.domain.roomInMember.vo;
+package com.mjuAppSW.joA.domain.memberProfile.vo;
 
 public interface UserInfoVO {
     String getName();

--- a/src/main/java/com/mjuAppSW/joA/domain/message/MessageApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/message/MessageApiController.java
@@ -32,7 +32,7 @@ public class MessageApiController {
         @ApiResponse(responseCode = "404", description = "R003: 방을 찾을 수 없습니다."),
         @ApiResponse(responseCode = "404", description = "RIM001: 채팅방을 찾을 수 없습니다.")
     })
-    @GetMapping("/{roomId}/{memberId}/messages")
+    @GetMapping("/{roomId}/{memberId}")
     public ResponseEntity<SuccessResponse<MessageResponse>> loadMessages(
         @Parameter(description = "방 id", in = ParameterIn.PATH) @PathVariable("roomId") Long roomId,
         @Parameter(description = "사용자 id", in = ParameterIn.PATH) @PathVariable("memberId") Long memberId){

--- a/src/main/java/com/mjuAppSW/joA/domain/report/message/MessageReportApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/report/message/MessageReportApiController.java
@@ -3,6 +3,8 @@ package com.mjuAppSW.joA.domain.report.message;
 import java.time.LocalDateTime;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -41,8 +43,8 @@ public class MessageReportApiController {
         return ResponseEntity.ok().build();
     }
 
-    @Operation(summary = "신고 메시지 삭제", description = "신고 메시지 삭제 API")
-    @PostMapping("/{messageReportId}/message/admin-delete")
+    @Operation(summary = "신고 메시지 삭제, 프론트에 적용되는 코드 X", description = "신고 메시지 삭제 API, 프론트에 적용되는 코드X")
+    @DeleteMapping("/{messageReportId}/message")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "상태 코드 응답"),
         @ApiResponse(responseCode = "404", description = "MR002: 신고된 메시지를 찾을 수 없습니다."),
@@ -59,7 +61,7 @@ public class MessageReportApiController {
         @ApiResponse(responseCode = "409", description = "MR003: 상대방을 신고한 메시지가 존재합니다."),
         @ApiResponse(responseCode = "409", description = "MR004: 상대방에게 신고된 메시지가 존재합니다."),
     })
-    @PostMapping("/message/check")
+    @GetMapping("/message")
     public ResponseEntity<Void> checkMessageReport(@RequestBody @Valid CheckMessageReportRequest request){
         messageReportService.checkMessageReport(request);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/mjuAppSW/joA/domain/room/RoomApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/room/RoomApiController.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -43,7 +44,7 @@ public class RoomApiController {
         @ApiResponse(responseCode = "404", description = "R003: 방을 찾을 수 없습니다."),
         @ApiResponse(responseCode = "400", description = "R002: 방이 생성된지 24시간이 지났습니다.")
     })
-    @PostMapping("/{id}/status")
+    @GetMapping("/{id}")
     public ResponseEntity<Void> checkCreateAtRoom(
             @Parameter(description = "방 id", in = ParameterIn.PATH) @PathVariable("id") Long roomId){
         roomService.checkCreateAtRoom(roomId);
@@ -53,9 +54,9 @@ public class RoomApiController {
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "방 연장 완료"),
         @ApiResponse(responseCode = "404", description = "R003: 방을 찾을 수 없습니다."),
-        @ApiResponse(responseCode = "409", description = "R004: 이미 연장된 채팅방입니다.")
+        @ApiResponse(responseCode = "409", description = "R004: 이미 연장된 방입니다.")
     })
-    @PatchMapping("/{id}/status")
+    @PatchMapping("/{id}")
     public ResponseEntity<Void> updateStatusAndDate(
          @Parameter(description = "방 id", in = ParameterIn.PATH) @PathVariable("id") Long roomId){
         LocalDateTime updateRoomStatusDate = LocalDateTime.now();

--- a/src/main/java/com/mjuAppSW/joA/domain/roomInMember/RoomInMemberApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/roomInMember/RoomInMemberApiController.java
@@ -59,7 +59,7 @@ public class RoomInMemberApiController {
         @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다."),
         @ApiResponse(responseCode = "404", description = "RIM001: 채팅방을 찾을 수 없습니다.")
     })
-    @PatchMapping("/expired")
+    @PatchMapping("/out")
     public ResponseEntity<Void> updateExpired(@RequestBody @Valid UpdateExpiredRequest request){
         roomInMemberService.updateExpired(request);
         return ResponseEntity.ok().build();
@@ -71,7 +71,7 @@ public class RoomInMemberApiController {
         @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다."),
         @ApiResponse(responseCode = "400", description = "RIM002: 이미 두 사용자의 채팅방이 존재합니다.")
     })
-    @GetMapping("/check")
+    @GetMapping("/existence")
     public ResponseEntity<Void> checkRoomInMember(@RequestBody @Valid CheckRoomInMemberRequest request){
         roomInMemberService.checkRoomInMember(request);
         return ResponseEntity.ok().build();

--- a/src/main/java/com/mjuAppSW/joA/domain/roomInMember/RoomInMemberApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/roomInMember/RoomInMemberApiController.java
@@ -71,7 +71,7 @@ public class RoomInMemberApiController {
         @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다."),
         @ApiResponse(responseCode = "400", description = "RIM002: 이미 두 사용자의 채팅방이 존재합니다.")
     })
-    @PostMapping("/check")
+    @GetMapping("/check")
     public ResponseEntity<Void> checkRoomInMember(@RequestBody @Valid CheckRoomInMemberRequest request){
         roomInMemberService.checkRoomInMember(request);
         return ResponseEntity.ok().build();
@@ -84,7 +84,7 @@ public class RoomInMemberApiController {
         @ApiResponse(responseCode = "404", description = "R003: 방을 찾을 수 없습니다."),
         @ApiResponse(responseCode = "404", description = "RIM001: 채팅방을 찾을 수 없습니다.")
     })
-    @GetMapping("/{roomId}/{memberId}/userInfo")
+    @GetMapping("/{roomId}/{memberId}/userinfo")
     public ResponseEntity<SuccessResponse<UserInfoResponse>> getUserInfo(@PathVariable("roomId") Long roomId, @PathVariable("memberId") Long memberId){
         return SuccessResponse.of(roomInMemberService.getUserInfo(roomId, memberId))
             .asHttp(HttpStatus.OK);

--- a/src/main/java/com/mjuAppSW/joA/domain/roomInMember/RoomInMemberApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/roomInMember/RoomInMemberApiController.java
@@ -76,17 +76,4 @@ public class RoomInMemberApiController {
         roomInMemberService.checkRoomInMember(request);
         return ResponseEntity.ok().build();
     }
-
-    @Operation(summary = "채팅방 입장시 상대방 정보 조회", description = "상대방 정보 조회 API")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "상대방 정보 반환"),
-        @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다."),
-        @ApiResponse(responseCode = "404", description = "R003: 방을 찾을 수 없습니다."),
-        @ApiResponse(responseCode = "404", description = "RIM001: 채팅방을 찾을 수 없습니다.")
-    })
-    @GetMapping("/{roomId}/{memberId}/userinfo")
-    public ResponseEntity<SuccessResponse<UserInfoResponse>> getUserInfo(@PathVariable("roomId") Long roomId, @PathVariable("memberId") Long memberId){
-        return SuccessResponse.of(roomInMemberService.getUserInfo(roomId, memberId))
-            .asHttp(HttpStatus.OK);
-    }
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/roomInMember/RoomInMemberRepository.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/roomInMember/RoomInMemberRepository.java
@@ -1,12 +1,13 @@
 package com.mjuAppSW.joA.domain.roomInMember;
 
 import com.mjuAppSW.joA.domain.member.Member;
+import com.mjuAppSW.joA.domain.memberProfile.vo.UserInfoVO;
 import com.mjuAppSW.joA.domain.room.Room;
 import com.mjuAppSW.joA.domain.roomInMember.vo.RoomInfoExceptMessageVO;
 import com.mjuAppSW.joA.domain.roomInMember.vo.RoomInfoIncludeMessageVO;
-import com.mjuAppSW.joA.domain.roomInMember.vo.UserInfoVO;
+
 import jakarta.transaction.Transactional;
-import java.time.LocalDateTime;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -72,6 +73,5 @@ public interface RoomInMemberRepository extends JpaRepository<RoomInMember, Long
             "From RoomInMember rim LEFT JOIN Member m ON rim.member.id = m.id " +
             "WHERE rim.room = :room AND rim.member <> :member")
     UserInfoVO getUserInfo(@Param("room") Room room, @Param("member") Member member);
-
 }
 

--- a/src/main/java/com/mjuAppSW/joA/domain/roomInMember/RoomInMemberService.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/roomInMember/RoomInMemberService.java
@@ -15,13 +15,11 @@ import com.mjuAppSW.joA.domain.roomInMember.dto.request.CheckRoomInMemberRequest
 import com.mjuAppSW.joA.domain.roomInMember.dto.request.UpdateExpiredRequest;
 import com.mjuAppSW.joA.domain.roomInMember.dto.request.VoteRequest;
 import com.mjuAppSW.joA.domain.roomInMember.dto.response.RoomListResponse;
-import com.mjuAppSW.joA.domain.roomInMember.dto.response.UserInfoResponse;
 import com.mjuAppSW.joA.domain.roomInMember.dto.response.VoteResponse;
 import com.mjuAppSW.joA.domain.roomInMember.vo.RoomInfoExceptMessageVO;
 import com.mjuAppSW.joA.domain.roomInMember.vo.RoomInfoIncludeMessageVO;
 import com.mjuAppSW.joA.domain.roomInMember.vo.RoomInfoVO;
 import com.mjuAppSW.joA.domain.roomInMember.vo.RoomInfoExceptDateVO;
-import com.mjuAppSW.joA.domain.roomInMember.vo.UserInfoVO;
 import com.mjuAppSW.joA.domain.roomInMember.exception.RoomInMemberAlreadyExistedException;
 import com.mjuAppSW.joA.domain.roomInMember.exception.RoomInMemberNotFoundException;
 
@@ -157,15 +155,6 @@ public class RoomInMemberService {
         for(RoomInMember rim : getRoomInMembers){
             if(rim.getExpired().equals(NOT_EXIT)){throw new RoomInMemberAlreadyExistedException();}
         }
-    }
-
-    public UserInfoResponse getUserInfo(Long roomId, Long memberId){
-        Room room = roomRepository.findById(roomId).orElseThrow(RoomNotFoundException::new);
-        Member member = memberChecker.findBySessionId(memberId);
-        RoomInMember roomInMember = roomInMemberRepository.findByRoomAndMember(room, member).orElseThrow(RoomInMemberNotFoundException::new);
-
-        UserInfoVO userInfoVO = roomInMemberRepository.getUserInfo(room, member);
-        return UserInfoResponse.of(userInfoVO.getName(), userInfoVO.getUrlCode(), userInfoVO.getBio());
     }
 
     @Transactional


### PR DESCRIPTION
# 요약
- API 가이드라인에 맞지 않는 URI들을 수정 및 간략화 하였습니다.
- Swagger 그룹명을 좀 더 정확히 명시하기 위해 수정하였고, 불필요한 주석을 삭제하였습니다.

# 체크 리스트
이 PR에는:

- [ ] 새로운 테스트의 추가 여부
- [x] 공개 API의 변경 여부
- [ ] 설계 문서의 포함 여부

# 본문
API URI가 전체적으로 수정해야 할 부분이 많아 보여 최대한 가이드라인에 맞추어 수정하였습니다.
앞서 말씀하셨던, **채팅방 목록 페이지 조회**와 **채팅방 입장시 상대방 정보 조회**를 member-profiles에 작성하는게 어떨까? 라는 의견을 주셨습니다.
 **채팅방 목록 페이지 조회**는 사용자 정보, 마지막으로 전송된 채팅, 방의 정보가 모두 포함된 정보로 이루어져 있어 기존 위치가 옳다고 생각이 들어 유지하였습니다.
 **채팅방 입장시 상대방 정보 조회**는 member-profiles에 작성하는 것이 적합하다는 생각이 들어 수정하였습니다.