### PR TITLE
API 응답 body 없는 경우 204 반환하도록 변경

### DIFF
--- a/src/main/java/com/mjuAppSW/joA/domain/member/controller/AccountApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/member/controller/AccountApiController.java
@@ -49,41 +49,41 @@ public class AccountApiController {
 
     @Operation(summary = "로그아웃", description = "로그아웃 API")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "204", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다.", content = @Content(schema = @Schema(hidden = true)))
     })
     @PostMapping("/{id}/logout")
     public ResponseEntity<Void> logout(@PathVariable("id") @NotNull Long sessionId) {
         accountService.logout(sessionId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "아이디 찾기", description = "아이디 찾기 API")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "로그인 id 웹메일 전송 후 HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "204", description = "로그인 id 웹메일 전송 후 HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404-1", description = "P001: 학교 정보를 찾을 수 없습니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404-2", description = "M001: 사용자를 찾을 수 없습니다.", content = @Content(schema = @Schema(hidden = true))),
     })
     @GetMapping("/id/find")
     public ResponseEntity<Void> findId(@RequestParam @NotBlank String collegeEmail, @RequestParam @NotNull Long collegeId) {
         accountService.findLoginId(collegeEmail, collegeId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "비밀번호 찾기", description = "비밀번호 찾기 API")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "임시 비밀번호 웹메일 전송 후 HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "204", description = "임시 비밀번호 웹메일 전송 후 HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다.", content = @Content(schema = @Schema(hidden = true))),
     })
     @GetMapping("/password/find")
     public ResponseEntity<Void> findPassword(@RequestParam @NotBlank String loginId) {
         accountService.findPassword(loginId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "비밀번호 변경", description = "비밀번호 변경 API")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "204", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404-1", description = "M001: 사용자를 찾을 수 없습니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404-2", description = "M015: 비밀번호가 올바르지 않습니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "400", description = "M012: 올바른 비밀번호 형식이 아닙니다.", content = @Content(schema = @Schema(hidden = true))),
@@ -91,18 +91,18 @@ public class AccountApiController {
     @PatchMapping("/password")
     public ResponseEntity<Void> transPassword(@RequestBody @Valid TransPasswordRequest request) {
         accountService.transPassword(request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "회원 탈퇴", description = "회원 탈퇴 API")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "204", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "500", description = "M003: S3 저장소 접근에 실패했습니다.", content = @Content(schema = @Schema(hidden = true)))
     })
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> withdrawal(@PathVariable("id") @NotNull Long sessionId) {
         accountService.withdrawal(sessionId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/member/controller/CertifyApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/member/controller/CertifyApiController.java
@@ -44,13 +44,13 @@ public class CertifyApiController {
 
     @Operation(summary = "인증 번호 검증", description = "회원가입 시 학교 웹메일을 확인하기 위해 전송된 인증번호를 확인하는 API")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "204", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404", description = "M007: 세션 id가 유효하지 않습니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "400", description = "M009: 인증번호가 올바르지 않습니다.", content = @Content(schema = @Schema(hidden = true))),
     })
     @PostMapping("/certify-num/verify")
     public ResponseEntity<Void> verifyCertifyNum(@RequestBody @Valid VerifyCertifyNumRequest request) {
         certifyService.verify(request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/member/controller/InfoApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/member/controller/InfoApiController.java
@@ -98,7 +98,7 @@ public class InfoApiController {
 
     @Operation(summary = "한 줄 소개 변경", description = "한 줄 소개 변경 API")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "204", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "403-1", description = "M003: 정지된 계정입니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "403-2", description = "M014: 영구 정지된 계정입니다.", content = @Content(schema = @Schema(hidden = true))),
@@ -107,12 +107,12 @@ public class InfoApiController {
     @PatchMapping("/bio")
     public ResponseEntity<Void> transBio(@RequestBody @Valid BioRequest request) {
         infoService.transBio(request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "한 줄 소개 삭제", description = "한 줄 소개 삭제 API")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "204", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "403-1", description = "M003: 정지된 계정입니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "403-2", description = "M014: 영구 정지된 계정입니다.", content = @Content(schema = @Schema(hidden = true))),
@@ -121,12 +121,12 @@ public class InfoApiController {
     public ResponseEntity<Void> deleteBio(
             @Parameter(description = "사용자 세션 id", in = ParameterIn.PATH) @PathVariable("id") Long sessionId) {
         infoService.deleteBio(sessionId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "프로필 사진 변경", description = "프로필 사진 변경 API")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "204", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "403-1", description = "M003: 정지된 계정입니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "403-2", description = "M014: 영구 정지된 계정입니다.", content = @Content(schema = @Schema(hidden = true))),
@@ -135,12 +135,12 @@ public class InfoApiController {
     @PatchMapping("/picture")
     public ResponseEntity<Void> transPicture(@RequestBody @Valid PictureRequest request) {
         infoService.transPicture(request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "프로필 사진 삭제", description = "프로필 사진 삭제 API")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "204", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "403-1", description = "M003: 정지된 계정입니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "403-2", description = "M014: 영구 정지된 계정입니다.", content = @Content(schema = @Schema(hidden = true))),
@@ -150,7 +150,7 @@ public class InfoApiController {
     public ResponseEntity<Void> deletePicture(
             @Parameter(description = "사용자 세션 id", in = ParameterIn.PATH) @PathVariable("id") Long sessionId) {
         infoService.deletePicture(sessionId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "채팅방 입장시 상대방 정보 조회", description = "상대방 정보 조회 API")

--- a/src/main/java/com/mjuAppSW/joA/domain/member/controller/JoinApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/member/controller/JoinApiController.java
@@ -27,7 +27,7 @@ public class JoinApiController {
 
     @Operation(summary = "아이디 중복 검증", description = "회원가입 시 중복 아이디가 존재하는지 확인하는 API")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "204", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "400-1", description = "M010: 올바른 아이디 형식이 아닙니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "400-2", description = "M008: 이메일 인증이 완료되지 않았습니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "409", description = "M011: 이미 사용 중인 아이디입니다.", content = @Content(schema = @Schema(hidden = true))),
@@ -36,12 +36,12 @@ public class JoinApiController {
     @PostMapping("/id/verify")
     public ResponseEntity<Void> verifyId(@RequestBody @Valid VerifyIdRequest request) {
         joinService.verifyLoginId(request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "회원 가입", description = "회원 가입 API")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "204", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "400-1", description = "M012: 올바른 비밀번호 형식이 아닙니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404-1", description = "M007: 세션 id가 유효하지 않습니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "400-2", description = "M013: 아이디 중복 확인이 완료되지 않았습니다.", content = @Content(schema = @Schema(hidden = true))),
@@ -51,6 +51,6 @@ public class JoinApiController {
     @PostMapping
     public ResponseEntity<Void> join(@RequestBody @Valid JoinRequest request) {
         joinService.join(request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/report/vote/VoteReportApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/report/vote/VoteReportApiController.java
@@ -25,7 +25,7 @@ public class VoteReportApiController {
 
     @Operation(summary = "투표 신고", description = "투표 신고 API")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "204", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404-1", description = "RC001: 신고 카테고리가 존재하지 않습니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404-2", description = "V001: 투표가 존재하지 않습니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404-3", description = "M001: 사용자를 찾을 수 없습니다.", content = @Content(schema = @Schema(hidden = true))),
@@ -34,6 +34,6 @@ public class VoteReportApiController {
     @PostMapping("/vote")
     public ResponseEntity<Void> execute(@RequestBody @Valid VoteReportRequest request) {
         voteReportService.execute(request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/vote/VoteApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/vote/VoteApiController.java
@@ -31,7 +31,7 @@ public class VoteApiController {
 
     @Operation(summary = "투표 전송", description = "투표 전송 API")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "상태 코드 반환"),
+            @ApiResponse(responseCode = "204", description = "상태 코드 반환"),
             @ApiResponse(responseCode = "404-1", description = "M001: 사용자를 찾을 수 없습니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "403-1", description = "M003: 정지된 계정입니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "403-2", description = "M014: 영구 정지된 계정입니다.", content = @Content(schema = @Schema(hidden = true))),
@@ -43,7 +43,7 @@ public class VoteApiController {
     @PostMapping
     public ResponseEntity<Void> send(@RequestBody @Valid VoteRequest request) {
         voteService.send(request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "받은 투표 목록 조회", description = "받은 투표 목록 조회 API")

--- a/src/main/java/com/mjuAppSW/joA/geography/block/BlockApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/geography/block/BlockApiController.java
@@ -23,7 +23,7 @@ public class BlockApiController {
     private final BlockService blockService;
     @Operation(summary = "사용자 차단", description = "사용자 차단 API")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "204", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404-1", description = "M001: 사용자를 찾을 수 없습니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "404-2", description = "L001: 사용자의 위치 정보를 찾을 수 없습니다.", content = @Content(schema = @Schema(hidden = true))),
             @ApiResponse(responseCode = "409", description = "B002: 이미 차단한 사용자입니다.", content = @Content(schema = @Schema(hidden = true))),
@@ -31,6 +31,6 @@ public class BlockApiController {
     @PostMapping
     public ResponseEntity<Void> create(@RequestBody BlockRequest blockRequest) {
         blockService.create(blockRequest);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/mjuAppSW/joA/geography/college/PCollegeApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/geography/college/PCollegeApiController.java
@@ -25,11 +25,11 @@ public class PCollegeApiController {
 
     @Operation(summary = "학교 범위 생성", description = "학교 범위 생성 API")
     @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
+            @ApiResponse(responseCode = "204", description = "HTTP 상태 코드 반환", content = @Content(schema = @Schema(hidden = true))),
     })
     @PostMapping
     public ResponseEntity<Void> create(@RequestBody @Valid PolygonRequest request) {
         pCollegeService.create(request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 }


### PR DESCRIPTION
# 요약
- API의 응답 body가 없는 경우 HTTP 상태코드를 200에서 204로 반환하도록 변경하였습니다.

# 체크 리스트
이 PR에는:

- [ ] 새로운 테스트의 추가 여부
- [x] 공개 API의 변경 여부
- [ ] 설계 문서의 포함 여부
