### PR TITLE
Controller, Service, Repository 리팩토링 및 API Body가 없는 경우 204 반환 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 	implementation 'org.springframework.boot:spring-boot-starter-log4j2'
 	implementation 'org.apache.logging.log4j:log4j-core:2.20.0'
+
+	implementation 'com.slack.api:slack-api-client:1.36.1'
+	implementation "net.gpedro.integrations.slack:slack-webhook:1.4.0"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/mjuAppSW/joA/common/config/SwaggerConfig.java
+++ b/src/main/java/com/mjuAppSW/joA/common/config/SwaggerConfig.java
@@ -133,7 +133,7 @@ public class SwaggerConfig {
 
         return GroupedOpenApi
                 .builder()
-                .group("방 API")
+                .group("채팅방 API")
                 .pathsToMatch(paths)
                 .build();
     }
@@ -144,7 +144,7 @@ public class SwaggerConfig {
 
         return GroupedOpenApi
                 .builder()
-                .group("채팅방 API")
+                .group("채팅방 사용자 API")
                 .pathsToMatch(paths)
                 .build();
     }

--- a/src/main/java/com/mjuAppSW/joA/common/constant/Constants.java
+++ b/src/main/java/com/mjuAppSW/joA/common/constant/Constants.java
@@ -36,13 +36,11 @@ public class Constants {
         public static String EXIT = "0";
         public static String NOT_EXIT = "1";
         public static String APPROVE_VOTE = "0";
-        public static String DISAPPROVE_OR_BEFORE_VOTE = "1";
+        public static String DISAPPROVE_VOTE = "1";
+        public static String BEFORE_VOTE = "2";
     }
 
     public static class MessageReport{
-        public static Integer REPORTED = 1;
-        public static Integer REPORT = 2;
-        public static Integer CLEAR = 3;
         public static Integer NINETY_DAY_HOURS = 2160;
     }
 

--- a/src/main/java/com/mjuAppSW/joA/common/exception/ErrorCode.java
+++ b/src/main/java/com/mjuAppSW/joA/common/exception/ErrorCode.java
@@ -62,6 +62,7 @@ public enum ErrorCode {
     // RoomInMember
     RIM_NOT_FOUND(404, "RIM001", "채팅방을 찾을 수 없습니다."),
     RIM_ALREADY_EXISTED(409, "RIM002", "이미 두 사용자의 채팅방이 존재합니다."),
+    RIM_ALREADY_VOTE_RESULT(409, "RIM003", "이미 채팅방 연장에 대한 투표가 존재합니다."),
 
     // MessageReport
     MESSAGE_REPORT_ALREADY_EXISTED(409, "MR001", "이미 신고된 메시지가 존재합니다."),

--- a/src/main/java/com/mjuAppSW/joA/domain/memberProfile/MemberProfileApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/memberProfile/MemberProfileApiController.java
@@ -7,7 +7,7 @@ import com.mjuAppSW.joA.domain.memberProfile.dto.request.PictureRequest;
 import com.mjuAppSW.joA.domain.memberProfile.dto.response.SettingPageResponse;
 import com.mjuAppSW.joA.domain.memberProfile.dto.response.VotePageResponse;
 import com.mjuAppSW.joA.domain.memberProfile.dto.response.LocationPageResponse;
-import com.mjuAppSW.joA.domain.memberProfile.dto.response.UserInfoResponse;
+import com.mjuAppSW.joA.domain.memberProfile.dto.response.ChattingPageResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -27,6 +27,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -159,8 +160,8 @@ public class MemberProfileApiController {
         @ApiResponse(responseCode = "404", description = "R003: 방을 찾을 수 없습니다."),
         @ApiResponse(responseCode = "404", description = "RIM001: 채팅방을 찾을 수 없습니다.")
     })
-    @GetMapping("/{roomId}/{memberId}/userinfo")
-    public ResponseEntity<SuccessResponse<UserInfoResponse>> getUserInfo(@PathVariable("roomId") Long roomId, @PathVariable("memberId") Long memberId){
+    @GetMapping("/userinfo")
+    public ResponseEntity<SuccessResponse<ChattingPageResponse>> getUserInfo(@RequestParam("roomId") Long roomId, @RequestParam("memberId") Long memberId){
         return SuccessResponse.of(memberProfileService.getUserInfo(roomId, memberId))
             .asHttp(HttpStatus.OK);
     }

--- a/src/main/java/com/mjuAppSW/joA/domain/memberProfile/MemberProfileService.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/memberProfile/MemberProfileService.java
@@ -10,8 +10,9 @@ import com.mjuAppSW.joA.domain.memberProfile.dto.request.BioRequest;
 import com.mjuAppSW.joA.domain.memberProfile.dto.response.MyPageResponse;
 import com.mjuAppSW.joA.domain.memberProfile.dto.request.PictureRequest;
 import com.mjuAppSW.joA.domain.memberProfile.dto.response.SettingPageResponse;
-import com.mjuAppSW.joA.domain.memberProfile.dto.response.UserInfoResponse;
+import com.mjuAppSW.joA.domain.memberProfile.dto.response.ChattingPageResponse;
 import com.mjuAppSW.joA.domain.memberProfile.exception.InvalidS3Exception;
+import com.mjuAppSW.joA.domain.memberProfile.exception.MemberNotFoundException;
 import com.mjuAppSW.joA.domain.room.Room;
 import com.mjuAppSW.joA.domain.room.RoomRepository;
 import com.mjuAppSW.joA.domain.room.exception.RoomNotFoundException;
@@ -64,14 +65,13 @@ public class MemberProfileService {
         return LocationPageResponse.of(memberChecker.findFilterBySessionId(sessionId));
     }
 
-    public UserInfoResponse getUserInfo(Long roomId, Long memberId){
-        Room room = roomRepository.findById(roomId).orElseThrow(RoomNotFoundException::new);
+    public ChattingPageResponse getUserInfo(Long roomId, Long memberId){
+        Room room = findByRoomId(roomId);
         Member member = memberChecker.findBySessionId(memberId);
-        RoomInMember roomInMember = roomInMemberRepository.findByRoomAndMember(room, member).orElseThrow(
-            RoomInMemberNotFoundException::new);
+        RoomInMember roomInMember = findByRoomAndMember(room, member);
 
-        UserInfoVO userInfoVO = roomInMemberRepository.getUserInfo(roomInMember.getRoom(), roomInMember.getMember());
-        return UserInfoResponse.of(userInfoVO.getName(), userInfoVO.getUrlCode(), userInfoVO.getBio());
+        UserInfoVO userInfoVO = findOpponentUserInfoByRoomAndMember(roomInMember.getRoom(), roomInMember.getMember());
+        return ChattingPageResponse.of(userInfoVO.getName(), userInfoVO.getUrlCode(), userInfoVO.getBio());
     }
 
     @Transactional
@@ -115,5 +115,20 @@ public class MemberProfileService {
             return;
         }
         throw new InvalidS3Exception();
+    }
+
+    private Room findByRoomId(Long roomId){
+        return roomRepository.findById(roomId)
+            .orElseThrow(RoomNotFoundException::new);
+    }
+
+    private RoomInMember findByRoomAndMember(Room room, Member member){
+        return roomInMemberRepository.findByRoomAndMember(room, member)
+            .orElseThrow(RoomInMemberNotFoundException::new);
+    }
+
+    private UserInfoVO findOpponentUserInfoByRoomAndMember(Room room, Member member){
+        return roomInMemberRepository.findOpponentUserInfoByRoomAndMember(room, member)
+            .orElseThrow(MemberNotFoundException::new);
     }
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/memberProfile/dto/response/ChattingPageResponse.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/memberProfile/dto/response/ChattingPageResponse.java
@@ -10,13 +10,13 @@ import lombok.RequiredArgsConstructor;
 @Schema(description = "채팅방 입장시 상대방 정보 조회 Response")
 @Builder(access = AccessLevel.PRIVATE)
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
-public class UserInfoResponse {
+public class ChattingPageResponse {
 	private final String name;
 	private final String urlCode;
 	private final String bio;
 
-	public static UserInfoResponse of(String name, String urlCode, String bio) {
-		return UserInfoResponse.builder()
+	public static ChattingPageResponse of(String name, String urlCode, String bio) {
+		return ChattingPageResponse.builder()
 			.name(name)
 			.urlCode(urlCode)
 			.bio(bio)

--- a/src/main/java/com/mjuAppSW/joA/domain/message/Message.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/message/Message.java
@@ -15,7 +15,6 @@ import java.util.Date;
 
 @Entity
 @Getter
-@Setter
 @NoArgsConstructor
 @Table(name = "Message")
 public class Message {

--- a/src/main/java/com/mjuAppSW/joA/domain/message/MessageApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/message/MessageApiController.java
@@ -16,6 +16,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -30,12 +31,12 @@ public class MessageApiController {
         @ApiResponse(responseCode = "200", description = "메시지 조회 완료"),
         @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다."),
         @ApiResponse(responseCode = "404", description = "R003: 방을 찾을 수 없습니다."),
-        @ApiResponse(responseCode = "404", description = "RIM001: 채팅방을 찾을 수 없습니다.")
+        @ApiResponse(responseCode = "404", description = "RIM001: 채팅방을 찾을 수 없습니다."),
+        @ApiResponse(responseCode = "500", description = "MG003: 메시지 복호화를 실패했습니다.")
     })
-    @GetMapping("/{roomId}/{memberId}")
+    @GetMapping
     public ResponseEntity<SuccessResponse<MessageResponse>> loadMessages(
-        @Parameter(description = "방 id", in = ParameterIn.PATH) @PathVariable("roomId") Long roomId,
-        @Parameter(description = "사용자 id", in = ParameterIn.PATH) @PathVariable("memberId") Long memberId){
+        @RequestParam("roomId") Long roomId, @RequestParam("memberId") Long memberId){
             return SuccessResponse.of(messageService.loadMessage(roomId, memberId))
                 .asHttp(HttpStatus.OK);
     }

--- a/src/main/java/com/mjuAppSW/joA/domain/message/MessageRepository.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/message/MessageRepository.java
@@ -26,7 +26,6 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
     @Query("SELECT COUNT(m) FROM Message m WHERE m.room = :room AND m.member = :member AND m.isChecked = '1'")
     Integer countUnCheckedMessage(@Param("room") Room room, @Param("member") Member member);
 
-
     @Query("SELECT m.content AS content, m.time AS time FROM Message m WHERE m.room = :room " +
             "AND m.content IS NULL OR m.content IS NOT NULL " +
             "AND (m.time IS NULL OR m.time = (SELECT MAX(mes2.time) FROM Message mes2 WHERE mes2.room = :room))")

--- a/src/main/java/com/mjuAppSW/joA/domain/message/MessageService.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/message/MessageService.java
@@ -3,7 +3,6 @@ package com.mjuAppSW.joA.domain.message;
 import com.mjuAppSW.joA.common.auth.MemberChecker;
 import com.mjuAppSW.joA.common.encryption.EncryptManager;
 import com.mjuAppSW.joA.domain.member.Member;
-import com.mjuAppSW.joA.domain.member.MemberRepository;
 import com.mjuAppSW.joA.domain.message.dto.vo.MessageVO;
 import com.mjuAppSW.joA.domain.message.dto.response.MessageResponse;
 import com.mjuAppSW.joA.domain.message.exception.FailDecryptException;
@@ -32,14 +31,13 @@ import java.util.stream.Collectors;
 public class MessageService {
     private final MessageRepository messageRepository;
     private final RoomRepository roomRepository;
-    private final MemberRepository memberRepository;
     private final RoomInMemberRepository roomInMemberRepository;
     private final MemberChecker memberChecker;
     private final EncryptManager encryptManager;
 
     @Transactional
     public Long saveMessage(Long roomId, Long memberId, String content, String isChecked, LocalDateTime createdMessageDate) {
-        Room room = roomRepository.findById(roomId).orElseThrow(RoomNotFoundException::new);
+        Room room = findByRoomId(roomId);
         Member member = memberChecker.findById(memberId);
         String encryptedMessage = encryptManager.encrypt(content, room.getEncryptKey());
         if(encryptedMessage == null){
@@ -56,35 +54,9 @@ public class MessageService {
         return saveMessage.getId();
     }
 
-    public MessageResponse loadMessage(Long roomId, Long memberId) {
-        Room room = roomRepository.findById(roomId).orElseThrow(RoomNotFoundException::new);
-        Member member = memberChecker.findBySessionId(memberId);
-        RoomInMember roomInMember = roomInMemberRepository.findByRoomAndMember(room, member).orElseThrow(
-            RoomInMemberNotFoundException::new);
-
-        List<Message> messageList = messageRepository.findByRoom(room);
-        if(messageList.isEmpty()){ return MessageResponse.of(new ArrayList<>());}
-
-        List<MessageVO> messageVOList = messageList.stream()
-            .map(message -> makeMessageContent(message, member, room))
-            .map(MessageVO::new)
-            .collect(Collectors.toList());
-
-        return MessageResponse.of(messageVOList);
-    }
-
-    private String makeMessageContent(Message message, Member member, Room room) {
-        String decryptedMessage = encryptManager.decrypt(message.getContent(), room.getEncryptKey());
-        if(decryptedMessage == null){
-            throw new FailDecryptException();
-        }
-        String messageType = (message.getMember() == member) ? "R" : "L";
-        return messageType + " " + message.getId() + " " + message.getIsChecked() + " " + decryptedMessage;
-    }
-
     @Transactional
     public void updateIsChecked(String roomId, String memberId){
-        Room room = roomRepository.findById(Long.parseLong(roomId)).orElseThrow(RoomNotFoundException::new);
+        Room room = findByRoomId(Long.parseLong(roomId));
         Member member = memberChecker.findById(Long.parseLong(memberId));
 
         List<Message> getMessages = messageRepository.findMessage(room, member);
@@ -93,5 +65,40 @@ public class MessageService {
                 message.updateIsChecked();
             }
         }
+    }
+
+    public MessageResponse loadMessage(Long roomId, Long memberId) {
+        Room room = findByRoomId(roomId);
+        Member member = memberChecker.findBySessionId(memberId);
+        RoomInMember roomInMember = findByRoomAndMember(room, member);
+
+        List<Message> messageList = messageRepository.findByRoom(roomInMember.getRoom());
+        if(messageList.isEmpty()){ return MessageResponse.of(new ArrayList<>());}
+
+        List<MessageVO> messageVOList = messageList.stream()
+            .map(message -> getMessage(message, roomInMember.getMember(), roomInMember.getRoom()))
+            .map(MessageVO::new)
+            .collect(Collectors.toList());
+
+        return MessageResponse.of(messageVOList);
+    }
+
+    private String getMessage(Message message, Member member, Room room) {
+        String decryptedMessage = encryptManager.decrypt(message.getContent(), room.getEncryptKey());
+        if(decryptedMessage == null){
+            throw new FailDecryptException();
+        }
+        String messageType = (message.getMember() == member) ? "R" : "L";
+        return messageType + " " + message.getId() + " " + message.getIsChecked() + " " + decryptedMessage;
+    }
+
+    private Room findByRoomId(Long roomId){
+        return roomRepository.findById(roomId)
+            .orElseThrow(RoomNotFoundException::new);
+    }
+
+    private RoomInMember findByRoomAndMember(Room room, Member member){
+        return roomInMemberRepository.findByRoomAndMember(room, member)
+            .orElseThrow(RoomInMemberNotFoundException::new);
     }
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/message/dto/response/MessageResponse.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/message/dto/response/MessageResponse.java
@@ -1,8 +1,10 @@
 package com.mjuAppSW.joA.domain.message.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
@@ -10,13 +12,10 @@ import com.mjuAppSW.joA.domain.message.dto.vo.MessageVO;
 
 @Getter
 @Schema(description = "채팅 목록 Response")
+@Builder(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class MessageResponse {
-    private List<MessageVO> messageResponseList;
-
-    @Builder
-    public MessageResponse(List<MessageVO> messageResponseList){
-        this.messageResponseList = messageResponseList;
-    }
+    private final List<MessageVO> messageResponseList;
 
     public static MessageResponse of(List<MessageVO> messageResponseList){
         return MessageResponse.builder()

--- a/src/main/java/com/mjuAppSW/joA/domain/message/dto/vo/GetCurrentMessage.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/message/dto/vo/GetCurrentMessage.java
@@ -1,8 +1,0 @@
-package com.mjuAppSW.joA.domain.message.dto.vo;
-
-import java.util.Date;
-
-public interface GetCurrentMessage {
-    String getContent();
-    Date getTime();
-}

--- a/src/main/java/com/mjuAppSW/joA/domain/message/exception/FailDecryptException.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/message/exception/FailDecryptException.java
@@ -5,6 +5,6 @@ import com.mjuAppSW.joA.common.exception.ErrorCode;
 
 public class FailDecryptException extends BusinessException {
 	public FailDecryptException(){
-		super(ErrorCode.FAIL_ENCRYPT);
+		super(ErrorCode.FAIL_DECRYPT);
 	}
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/report/message/MessageReport.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/report/message/MessageReport.java
@@ -22,7 +22,6 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Entity
-@Setter
 @Getter
 @NoArgsConstructor
 @Table(name="Message_report")

--- a/src/main/java/com/mjuAppSW/joA/domain/report/message/MessageReportApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/report/message/MessageReportApiController.java
@@ -4,14 +4,12 @@ import java.time.LocalDateTime;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.mjuAppSW.joA.domain.report.message.dto.request.CheckMessageReportRequest;
 import com.mjuAppSW.joA.domain.report.message.dto.request.ReportRequest;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -51,19 +49,6 @@ public class MessageReportApiController {
     })
     public ResponseEntity<Void> deleteMessageReportAdmin(@PathVariable("messageReportId") Long messageReportId){
         messageReportService.deleteMessageReportAdmin(messageReportId);
-        return ResponseEntity.ok().build();
-    }
-
-    @Operation(summary = "채팅방 생성 전 신고된 메시지 확인", description = "채팅방 생성 전 신고된 메시지가 존재하는 사용자 조회 API")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "신고된 메시지가 없습니다."),
-        @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다."),
-        @ApiResponse(responseCode = "409", description = "MR003: 상대방을 신고한 메시지가 존재합니다."),
-        @ApiResponse(responseCode = "409", description = "MR004: 상대방에게 신고된 메시지가 존재합니다."),
-    })
-    @GetMapping("/message")
-    public ResponseEntity<Void> checkMessageReport(@RequestBody @Valid CheckMessageReportRequest request){
-        messageReportService.checkMessageReport(request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/report/message/MessageReportApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/report/message/MessageReportApiController.java
@@ -28,7 +28,7 @@ public class MessageReportApiController {
     private final MessageReportService messageReportService;
     @Operation(summary = "메시지 신고", description = "메시지 신고 API")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "상태 코드 응답"),
+        @ApiResponse(responseCode = "204", description = "HTTP 상태 코드 반환"),
         @ApiResponse(responseCode = "404", description = "RC001: 신고 카테고리가 존재하지 않습니다."),
         @ApiResponse(responseCode = "404", description = "MG001: 메시지를 찾을 수 없습니다."),
         @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다."),
@@ -38,17 +38,17 @@ public class MessageReportApiController {
     public ResponseEntity<Void> messageReport(@RequestBody @Valid ReportRequest request){
         LocalDateTime messageReportDate = LocalDateTime.now();
         messageReportService.messageReport(request, messageReportDate);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "신고 메시지 삭제, 프론트에 적용되는 코드 X", description = "신고 메시지 삭제 API, 프론트에 적용되는 코드X")
+    @Operation(summary = "신고 메시지 삭제", description = "신고 메시지 삭제 API")
     @DeleteMapping("/{messageReportId}/message")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "상태 코드 응답"),
+        @ApiResponse(responseCode = "204", description = "HTTP 상태 코드 반환"),
         @ApiResponse(responseCode = "404", description = "MR002: 신고된 메시지를 찾을 수 없습니다."),
     })
     public ResponseEntity<Void> deleteMessageReportAdmin(@PathVariable("messageReportId") Long messageReportId){
         messageReportService.deleteMessageReportAdmin(messageReportId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/report/message/MessageReportRepository.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/report/message/MessageReportRepository.java
@@ -16,8 +16,8 @@ public interface MessageReportRepository extends JpaRepository<MessageReport, Lo
     @Query("SELECT mr FROM MessageReport mr Where mr.message_id = :message")
     Optional<MessageReport> findByMessage(@Param("message") Message message);
 
-    @Query("SELECT mr FROM MessageReport mr WHERE mr.message_id.member.id = :memberId1")
-    List<MessageReport> findByMemberId(@Param("memberId1") Long memberId1);
+    @Query("SELECT mr FROM MessageReport mr WHERE mr.message_id.member.id = :memberId")
+    List<MessageReport> findByMemberId(@Param("memberId") Long memberId);
 
     @Query("SELECT mr FROM MessageReport mr WHERE mr.message_id.room = :room")
     List<MessageReport> findByRoomId(@Param("room") Room room);

--- a/src/main/java/com/mjuAppSW/joA/domain/report/message/MessageReportService.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/report/message/MessageReportService.java
@@ -5,9 +5,7 @@ import static com.mjuAppSW.joA.common.constant.Constants.MessageReport.*;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
@@ -19,16 +17,10 @@ import com.mjuAppSW.joA.domain.message.MessageRepository;
 import com.mjuAppSW.joA.domain.message.exception.MessageNotFoundException;
 import com.mjuAppSW.joA.domain.report.ReportCategory;
 import com.mjuAppSW.joA.domain.report.ReportCategoryRepository;
-import com.mjuAppSW.joA.domain.report.message.dto.request.CheckMessageReportRequest;
 import com.mjuAppSW.joA.domain.report.message.dto.request.ReportRequest;
 import com.mjuAppSW.joA.domain.report.message.exception.MessageReportAlreadyExistedException;
-import com.mjuAppSW.joA.domain.report.message.exception.MessageReportAlreadyReportException;
-import com.mjuAppSW.joA.domain.report.message.exception.MessageReportAlreadyReportedException;
 import com.mjuAppSW.joA.domain.report.message.exception.MessageReportNotFoundException;
 import com.mjuAppSW.joA.domain.report.vote.exception.ReportCategoryNotFoundException;
-import com.mjuAppSW.joA.domain.room.Room;
-import com.mjuAppSW.joA.domain.roomInMember.RoomInMember;
-import com.mjuAppSW.joA.domain.roomInMember.RoomInMemberRepository;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -42,19 +34,13 @@ public class MessageReportService {
     private final MessageReportRepository messageReportRepository;
     private final MessageRepository messageRepository;
     private final ReportCategoryRepository reportCategoryRepository;
-    private final RoomInMemberRepository roomInMemberRepository;
     private final MemberChecker memberChecker;
 
     @Transactional
     public void messageReport(ReportRequest request, LocalDateTime messageReportDate){
-        Message message = messageRepository.findById(request.getMessageId()).orElseThrow(MessageNotFoundException::new);
-        ReportCategory reportCategory = reportCategoryRepository.findById(request.getCategoryId()).orElseThrow(
-            ReportCategoryNotFoundException::new);
-        MessageReport check = messageReportRepository.findByMessage(message).orElse(null);
-
-        if(check != null){
-            throw new MessageReportAlreadyExistedException();
-        }
+        Message message = findByMessageId(request.getMessageId());
+        ReportCategory reportCategory = findByCategoryId(request.getCategoryId());
+        checkExistedReportMessage(message);
 
         MessageReport messageReport = MessageReport.builder()
             .message_id(message)
@@ -69,49 +55,30 @@ public class MessageReportService {
         member.addReportCount();
     }
 
-    public boolean check(List<MessageReport> messageReports, Long memberId1, Long memberId2){
-        Set<Room> roomIds = new HashSet<>();
-        if(messageReports != null){
-            for(MessageReport mr : messageReports){
-                roomIds.add(mr.getMessage_id().getRoom());
-            }
-        }
-
-        for(Room rId : roomIds){
-            List<RoomInMember> roomInMembers = roomInMemberRepository.findByAllRoom(rId);
-            boolean memberId1Exists = roomInMembers.stream()
-                    .anyMatch(rim -> rim.getMember().getId().equals(memberId1));
-            boolean memberId2Exists = roomInMembers.stream()
-                    .anyMatch(rim -> rim.getMember().getId().equals(memberId2));
-            if(memberId1Exists && memberId2Exists){
-                return true;
-            }
-        }
-        return false;
-    }
-    public void checkMessageReport(CheckMessageReportRequest request){
-        Member member1 = memberChecker.findBySessionId(request.getMemberId1());
-        Member member2 = memberChecker.findById(request.getMemberId2());
-
-        List<MessageReport> myMessageReport = messageReportRepository.findByMemberId(member1.getId());
-        List<MessageReport> opponentMessageReport = messageReportRepository.findByMemberId(member2.getId());
-        Boolean reported = check(myMessageReport, member1.getId(), member2.getId());
-        Boolean report = check(opponentMessageReport, member1.getId(), member2.getId());
-        if(reported && report){throw new MessageReportAlreadyReportedException();}
-        else if(reported){throw new MessageReportAlreadyReportedException();}
-        else if(report){throw new MessageReportAlreadyReportException();}
-    }
     @Transactional
     public void deleteMessageReportAdmin(Long id){
-        MessageReport messageReport = messageReportRepository.findById(id).orElseThrow(MessageReportNotFoundException::new);
+        MessageReport messageReport = findByMessageReportId(id);
         messageReportRepository.delete(messageReport);
     }
 
-    public Long calculationHour(LocalDateTime getTime){
-        LocalDateTime currentDateTime = LocalDateTime.now();
-        Duration duration = Duration.between(getTime, currentDateTime);
-        Long hours = duration.toHours();
-        return hours;
+    private Message findByMessageId(Long messageId){
+        return messageRepository.findById(messageId)
+            .orElseThrow(MessageNotFoundException::new);
+    }
+    private MessageReport findByMessageReportId(Long messageReportId){
+        return messageReportRepository.findById(messageReportId)
+            .orElseThrow(MessageReportNotFoundException::new);
+    }
+    private ReportCategory findByCategoryId(Long categoryId){
+        return reportCategoryRepository.findById(categoryId)
+            .orElseThrow(ReportCategoryNotFoundException::new);
+    }
+
+    private void checkExistedReportMessage(Message message){
+        messageReportRepository.findByMessage(message)
+            .ifPresent(messageReport -> {
+                throw new MessageReportAlreadyExistedException();
+            });
     }
 
     @Scheduled(cron = "0 55 23 14,L * ?")
@@ -131,5 +98,11 @@ public class MessageReportService {
                 messageReportRepository.delete(mr);
             }
         }
+    }
+    private Long calculationHour(LocalDateTime getTime){
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        Duration duration = Duration.between(getTime, currentDateTime);
+        Long hours = duration.toHours();
+        return hours;
     }
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/report/message/dto/request/ReportRequest.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/report/message/dto/request/ReportRequest.java
@@ -3,12 +3,16 @@ package com.mjuAppSW.joA.domain.report.message.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @Schema(description = "메시지 신고 Request")
+@RequiredArgsConstructor
+@NoArgsConstructor(force = true)
 public class ReportRequest {
     @NotNull
-    private Long messageId;
+    private final Long messageId;
     @NotNull
-    private Long categoryId;
+    private final Long categoryId;
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/room/Room.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/room/Room.java
@@ -14,7 +14,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 @Entity
-@Setter
 @Getter
 @NoArgsConstructor
 @Table(name="Room")

--- a/src/main/java/com/mjuAppSW/joA/domain/room/RoomApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/room/RoomApiController.java
@@ -46,7 +46,7 @@ public class RoomApiController {
 
     @Operation(summary = "채팅방 생성 시간 조회", description = "채팅방 페이지에서 투표를 누르기 전 유효기간을 확인하는 API")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "방이 생성된지 24시간이 지나지 않았습니다."),
+        @ApiResponse(responseCode = "204", description = "HTTP 상태 코드 반환"),
         @ApiResponse(responseCode = "404", description = "R003: 방을 찾을 수 없습니다."),
         @ApiResponse(responseCode = "400", description = "R002: 방이 생성된지 24시간이 지났습니다.")
     })
@@ -54,12 +54,12 @@ public class RoomApiController {
     public ResponseEntity<Void> checkCreateAtRoom(
             @Parameter(description = "방 id", in = ParameterIn.PATH) @PathVariable("id") Long roomId){
         roomService.checkCreateAtRoom(roomId);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "채팅방 상태 연장", description = "채팅방 페이지에서 투표가 완료되었을 때 유효기간을 연장하는 API")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "방 연장 완료"),
+        @ApiResponse(responseCode = "204", description = "HTTP 상태 코드 반환"),
         @ApiResponse(responseCode = "404", description = "R003: 방을 찾을 수 없습니다."),
         @ApiResponse(responseCode = "409", description = "R004: 이미 연장된 방입니다.")
     })
@@ -68,24 +68,24 @@ public class RoomApiController {
          @Parameter(description = "방 id", in = ParameterIn.PATH) @PathVariable("id") Long roomId){
         LocalDateTime updateRoomStatusDate = LocalDateTime.now();
         roomService.updateStatusAndDate(roomId, updateRoomStatusDate);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "채팅방 생성 전 채팅방 유무 확인", description = "채팅방 생성 전 이미 두 사용자의 채팅방이 존재하는지 확인 API")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "상태코드 반환"),
+        @ApiResponse(responseCode = "204", description = "HTTP 상태 코드 반환"),
         @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다."),
         @ApiResponse(responseCode = "400", description = "RIM002: 이미 두 사용자의 채팅방이 존재합니다.")
     })
     @GetMapping("/existence")
     public ResponseEntity<Void> checkRoomInMember(@RequestParam("memberId1") Long memberId1, @RequestParam("memberId2") Long memberId2){
         roomService.checkRoomInMember(memberId1, memberId2);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "채팅방 생성 전 신고된 메시지 확인", description = "채팅방 생성 전 신고된 메시지가 존재하는 사용자 조회 API")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "신고된 메시지가 없습니다."),
+        @ApiResponse(responseCode = "204", description = "HTTP 상태 코드 반환"),
         @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다."),
         @ApiResponse(responseCode = "409", description = "MR003: 상대방을 신고한 메시지가 존재합니다."),
         @ApiResponse(responseCode = "409", description = "MR004: 상대방에게 신고된 메시지가 존재합니다."),
@@ -93,6 +93,6 @@ public class RoomApiController {
     @GetMapping("/report-message")
     public ResponseEntity<Void> checkMessageReport(@RequestParam("memberId1") Long memberId1, @RequestParam("memberId2") Long memberId2){
         roomService.checkMessageReport(memberId1, memberId2);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/room/RoomApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/room/RoomApiController.java
@@ -3,13 +3,16 @@ package com.mjuAppSW.joA.domain.room;
 import java.time.LocalDateTime;
 
 import com.mjuAppSW.joA.common.dto.SuccessResponse;
+import com.mjuAppSW.joA.domain.room.dto.request.CheckMessageReportRequest;
 import com.mjuAppSW.joA.domain.room.dto.response.RoomResponse;
+import com.mjuAppSW.joA.domain.room.dto.request.CheckRoomInMemberRequest;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -18,7 +21,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -29,16 +34,17 @@ public class RoomApiController {
 
     private final RoomService roomService;
 
-    @Operation(summary = "방 생성", description = "메인 페이지에서 하트가 눌렸을 때 방을 생성하는 API")
+    @Operation(summary = "채팅방 생성", description = "메인 페이지에서 하트가 눌렸을 때 방을 생성하는 API")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "방 생성 완료")
     })
-    @PostMapping()
+    @PostMapping
     public ResponseEntity<SuccessResponse<RoomResponse>> createRoom(){
         LocalDateTime createdRoomDate = LocalDateTime.now();
         return SuccessResponse.of(roomService.createRoom(createdRoomDate)).asHttp(HttpStatus.OK);
     }
-    @Operation(summary = "방 생성 시간 조회", description = "채팅방 페이지에서 투표를 누르기 전 유효기간을 확인하는 API")
+
+    @Operation(summary = "채팅방 생성 시간 조회", description = "채팅방 페이지에서 투표를 누르기 전 유효기간을 확인하는 API")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "방이 생성된지 24시간이 지나지 않았습니다."),
         @ApiResponse(responseCode = "404", description = "R003: 방을 찾을 수 없습니다."),
@@ -50,7 +56,8 @@ public class RoomApiController {
         roomService.checkCreateAtRoom(roomId);
         return ResponseEntity.ok().build();
     }
-    @Operation(summary = "방 상태 연장", description = "채팅방 페이지에서 투표가 완료되었을 때 유효기간을 연장하는 API")
+
+    @Operation(summary = "채팅방 상태 연장", description = "채팅방 페이지에서 투표가 완료되었을 때 유효기간을 연장하는 API")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "방 연장 완료"),
         @ApiResponse(responseCode = "404", description = "R003: 방을 찾을 수 없습니다."),
@@ -61,6 +68,31 @@ public class RoomApiController {
          @Parameter(description = "방 id", in = ParameterIn.PATH) @PathVariable("id") Long roomId){
         LocalDateTime updateRoomStatusDate = LocalDateTime.now();
         roomService.updateStatusAndDate(roomId, updateRoomStatusDate);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "채팅방 생성 전 채팅방 유무 확인", description = "채팅방 생성 전 이미 두 사용자의 채팅방이 존재하는지 확인 API")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "상태코드 반환"),
+        @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다."),
+        @ApiResponse(responseCode = "400", description = "RIM002: 이미 두 사용자의 채팅방이 존재합니다.")
+    })
+    @GetMapping("/existence")
+    public ResponseEntity<Void> checkRoomInMember(@RequestParam("memberId1") Long memberId1, @RequestParam("memberId2") Long memberId2){
+        roomService.checkRoomInMember(memberId1, memberId2);
+        return ResponseEntity.ok().build();
+    }
+
+    @Operation(summary = "채팅방 생성 전 신고된 메시지 확인", description = "채팅방 생성 전 신고된 메시지가 존재하는 사용자 조회 API")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "신고된 메시지가 없습니다."),
+        @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다."),
+        @ApiResponse(responseCode = "409", description = "MR003: 상대방을 신고한 메시지가 존재합니다."),
+        @ApiResponse(responseCode = "409", description = "MR004: 상대방에게 신고된 메시지가 존재합니다."),
+    })
+    @GetMapping("/report-message")
+    public ResponseEntity<Void> checkMessageReport(@RequestParam("memberId1") Long memberId1, @RequestParam("memberId2") Long memberId2){
+        roomService.checkMessageReport(memberId1, memberId2);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/room/RoomRepository.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/room/RoomRepository.java
@@ -18,6 +18,6 @@ public interface RoomRepository extends JpaRepository<Room, Long> {
     List<Room> findByStatus(@Param("status") String status);
 
     @Query("SELECT r FROM Room r WHERE r.status = :status AND r.id Not IN :roomIds")
-    List<Room> findByStatusAndRoomIds(@Param("status") String status, @Param("roomIds") Set<Long> roomIds);
+    List<Room> findByStatusAndNotRoomIds(@Param("status") String status, @Param("roomIds") Set<Long> roomIds);
 }
 

--- a/src/main/java/com/mjuAppSW/joA/domain/room/RoomService.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/room/RoomService.java
@@ -3,24 +3,34 @@ package com.mjuAppSW.joA.domain.room;
 import static com.mjuAppSW.joA.common.constant.Constants.Room.*;
 import static com.mjuAppSW.joA.common.constant.Constants.Room.OVER_ONE_DAY;
 import static com.mjuAppSW.joA.common.constant.Constants.Room.OVER_SEVEN_DAY;
+import static com.mjuAppSW.joA.common.constant.Constants.RoomInMember.*;
 import static com.mjuAppSW.joA.common.constant.Constants.WebSocketHandler.*;
 
+import com.mjuAppSW.joA.common.auth.MemberChecker;
 import com.mjuAppSW.joA.common.encryption.EncryptManager;
+import com.mjuAppSW.joA.domain.member.Member;
 import com.mjuAppSW.joA.domain.message.MessageRepository;
 import com.mjuAppSW.joA.domain.report.message.MessageReport;
 import com.mjuAppSW.joA.domain.report.message.MessageReportRepository;
+import com.mjuAppSW.joA.domain.room.dto.request.CheckMessageReportRequest;
+import com.mjuAppSW.joA.domain.report.message.exception.MessageReportAlreadyReportException;
+import com.mjuAppSW.joA.domain.report.message.exception.MessageReportAlreadyReportedException;
 import com.mjuAppSW.joA.domain.room.dto.response.RoomResponse;
 import com.mjuAppSW.joA.domain.room.exception.OverOneDayException;
 import com.mjuAppSW.joA.domain.room.exception.RoomAlreadyExtendException;
 import com.mjuAppSW.joA.domain.room.exception.RoomNotFoundException;
+import com.mjuAppSW.joA.domain.roomInMember.RoomInMember;
 import com.mjuAppSW.joA.domain.roomInMember.RoomInMemberRepository;
+import com.mjuAppSW.joA.domain.room.dto.request.CheckRoomInMemberRequest;
+import com.mjuAppSW.joA.domain.roomInMember.exception.RoomInMemberAlreadyExistedException;
+import com.mjuAppSW.joA.domain.roomInMember.exception.RoomInMemberAlreadyVoteResultException;
+
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
-import java.security.SecureRandom;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.*;
@@ -36,6 +46,7 @@ public class RoomService {
     private final MessageRepository messageRepository;
     private final MessageReportRepository messageReportRepository;
     private final EncryptManager encryptManager;
+    private final MemberChecker memberChecker;
 
     @Transactional
     public RoomResponse createRoom(LocalDateTime createdRoomDate){
@@ -49,46 +60,103 @@ public class RoomService {
     }
 
     @Transactional
-    public void updateStatusAndDate(Long roomId, LocalDateTime updateRoomStatusDate){
-        Room room = roomRepository.findById(roomId).orElseThrow(RoomNotFoundException::new);
-        if(room.getStatus().equals(EXTEND)){
+    public void updateStatusAndDate(Long roomId, LocalDateTime updateRoomStatusDate) {
+        Room room = findByRoomId(roomId);
+        if (room.getStatus().equals(EXTEND)) {
             throw new RoomAlreadyExtendException();
         }
         room.updateStatusAndDate(updateRoomStatusDate);
     }
 
-    public Long calculationHour(LocalDateTime getTime){
-        LocalDateTime currentDateTime = LocalDateTime.now();
-        Duration duration = Duration.between(getTime, currentDateTime);
-        Long hours = duration.toHours();
-        return hours;
+    public void checkRoomInMember(Long memberId1, Long memberId2) {
+        Member member1 = memberChecker.findBySessionId(memberId1);
+        Member member2 = memberChecker.findById(memberId2);
+        List<RoomInMember> roomInMemberList = roomInMemberRepository.checkRoomInMember(member1, member2);
+        if(!roomInMemberList.isEmpty()){
+            throw new RoomInMemberAlreadyExistedException();
+        }
+    }
+    public void checkMessageReport(Long memberId1, Long memberId2){
+        Member member1 = memberChecker.findBySessionId(memberId1);
+        Member member2 = memberChecker.findById(memberId2);
+
+        List<MessageReport> myMessageReport = messageReportRepository.findByMemberId(member1.getId());
+        List<MessageReport> opponentMessageReport = messageReportRepository.findByMemberId(member2.getId());
+        Boolean reported = checkReportMessages(myMessageReport, member1.getId(), member2.getId());
+        Boolean report = checkReportMessages(opponentMessageReport, member1.getId(), member2.getId());
+        if(reported && report){throw new MessageReportAlreadyReportedException();}
+        if(reported){throw new MessageReportAlreadyReportedException();}
+        if(report){throw new MessageReportAlreadyReportException();}
+    }
+
+    private boolean checkReportMessages(List<MessageReport> messageReports, Long memberId1, Long memberId2){
+        Set<Room> roomIds = new HashSet<>();
+        if(messageReports != null){
+            for(MessageReport mr : messageReports){
+                roomIds.add(mr.getMessage_id().getRoom());
+            }
+        }
+
+        for(Room rId : roomIds){
+            List<RoomInMember> roomInMembers = roomInMemberRepository.findByAllRoom(rId);
+            boolean memberId1Exists = roomInMembers.stream()
+                .anyMatch(rim -> rim.getMember().getId().equals(memberId1));
+            boolean memberId2Exists = roomInMembers.stream()
+                .anyMatch(rim -> rim.getMember().getId().equals(memberId2));
+            if(memberId1Exists && memberId2Exists){
+                return true;
+            }
+        }
+        return false;
     }
 
     public void checkCreateAtRoom(Long roomId){
-        Room room = roomRepository.findById(roomId).orElseThrow(RoomNotFoundException::new);
+        Room room = findByRoomId(roomId);
         LocalDateTime getDate = room.getDate();
         Long hours = calculationHour(getDate);
-        if(hours > ONE_DAY_HOURS){
+        if(hours >= ONE_DAY_HOURS){
             throw new OverOneDayException();
         }
     }
 
     public Integer checkTime(Long roomId){
-        Room room = roomRepository.findById(roomId).orElseThrow(RoomNotFoundException::new);
+        Room room = findByRoomId(roomId);
 
         String status = room.getStatus();
         LocalDateTime date = room.getDate();
         Long hours = calculationHour(date);
         if(status.equals(EXTEND)){
             if (hours >= SEVEN_DAY_HOURS){return OVER_SEVEN_DAY;}
-        }else {
+        }
+        if(status.equals(NOT_EXTEND)){
             if (hours >= ONE_DAY_HOURS) {return OVER_ONE_DAY;}
         }
         return NORMAL_OPERATION;
     }
 
+    private Long calculationHour(LocalDateTime getTime){
+        LocalDateTime currentDateTime = LocalDateTime.now();
+        Duration duration = Duration.between(getTime, currentDateTime);
+        Long hours = duration.toHours();
+        return hours;
+    }
+
+    public void findByRoom(Long roomId){
+        Room room = roomRepository.findById(roomId).orElseThrow(RoomNotFoundException::new);
+
+        List<RoomInMember> roomInMemberList = roomInMemberRepository.findAllRoom(room);
+        if(!roomInMemberList.isEmpty()){
+            throw new RoomInMemberAlreadyExistedException();
+        }
+    }
+
+    private Room findByRoomId(Long roomId){
+        return roomRepository.findById(roomId)
+            .orElseThrow(RoomNotFoundException::new);
+    }
+
     @Scheduled(cron = "0 0 0,12 * * *") // Run at 00, 12 o'clock every day
-    public void performScheduledTask(){
+    public void deleteRooms(){
         log.info("00, 12 delete Room");
         List<MessageReport> messageReports = messageReportRepository.findAll();
         Set<Long> roomIds = new HashSet<>();
@@ -97,24 +165,20 @@ public class RoomService {
                 roomIds.add(mr.getMessage_id().getRoom().getId());
             }
         }
-        List<Room> rooms0;
-        if(roomIds.isEmpty()){rooms0 = roomRepository.findByStatus(EXTEND);}
-        else{rooms0 = roomRepository.findByStatusAndRoomIds(EXTEND, roomIds);}
-        for(Room room : rooms0){
+
+        checkStatus(roomIds, EXTEND, SEVEN_DAY_HOURS);
+        checkStatus(roomIds, NOT_EXTEND, ONE_DAY_HOURS);
+    }
+
+    private void checkStatus(Set<Long> roomIds, String status, int validTime){
+        List<Room> rooms;
+        if(roomIds.isEmpty()){rooms = roomRepository.findByStatus(status);}
+        else{rooms = roomRepository.findByStatusAndNotRoomIds(status, roomIds);}
+
+        for(Room room : rooms){
             LocalDateTime date = room.getDate();
-            Long hours = calculationHour(date);
-            if(hours > SEVEN_DAY_HOURS){
-                log.info("delete : roomId = {}", room.getId());
-                deleteMemory(room);
-            }
-        }
-        List<Room> rooms1;
-        if(roomIds.isEmpty()){rooms1 = roomRepository.findByStatus(NOT_EXTEND);}
-        else{rooms1 = roomRepository.findByStatusAndRoomIds(NOT_EXTEND, roomIds);}
-        for(Room room : rooms1){
-            LocalDateTime date = room.getDate();
-            Long hours = calculationHour(date);
-            if(hours > ONE_DAY_HOURS){
+            Long calculateHours = calculationHour(date);
+            if(calculateHours > validTime){
                 log.info("delete : roomId = {}", room.getId());
                 deleteMemory(room);
             }

--- a/src/main/java/com/mjuAppSW/joA/domain/room/dto/request/CheckMessageReportRequest.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/room/dto/request/CheckMessageReportRequest.java
@@ -1,16 +1,18 @@
-package com.mjuAppSW.joA.domain.report.message.dto.request;
-
-import com.fasterxml.jackson.annotation.JsonProperty;
+package com.mjuAppSW.joA.domain.room.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @Schema(description = "채팅방 생성 전 신고된 메시지 확인 Request")
+@RequiredArgsConstructor
+@NoArgsConstructor(force = true)
 public class CheckMessageReportRequest {
     @NotNull
-    private Long memberId1;
+    private final Long memberId1;
     @NotNull
-    private Long memberId2;
+    private final Long memberId2;
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/room/dto/request/CheckRoomInMemberRequest.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/room/dto/request/CheckRoomInMemberRequest.java
@@ -1,14 +1,18 @@
-package com.mjuAppSW.joA.domain.roomInMember.dto.request;
+package com.mjuAppSW.joA.domain.room.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @Schema(description = "채팅방 생성 전 채팅방 유무 확인 Request")
+@RequiredArgsConstructor
+@NoArgsConstructor(force = true)
 public class CheckRoomInMemberRequest {
     @NotNull
-    private Long memberId1;
+    private final Long memberId1;
     @NotNull
-    private Long memberId2;
+    private final Long memberId2;
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/room/dto/response/RoomResponse.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/room/dto/response/RoomResponse.java
@@ -1,18 +1,17 @@
 package com.mjuAppSW.joA.domain.room.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @Schema(description = "방 생성 후 RoomId Response")
+@Builder(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class RoomResponse {
-    private Long roomId;
-
-    @Builder
-    public RoomResponse(Long roomId){
-        this.roomId = roomId;
-    }
+    private final Long roomId;
 
     public static RoomResponse of(Long roomId) {
         return RoomResponse.builder()

--- a/src/main/java/com/mjuAppSW/joA/domain/roomInMember/RoomInMember.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/roomInMember/RoomInMember.java
@@ -6,13 +6,10 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
-@Setter
 @Getter
 @Table(name="Room_in_member")
 @IdClass(RoomInMemberId.class)
@@ -55,5 +52,5 @@ public class RoomInMember {
     }
     public void updateExpired(String expired) { this.expired = expired; }
     public void updateEntryTime(LocalDateTime entryTime){ this.entryTime = entryTime; }
-    public void updateExitTime(LocalDateTime exitTime) { this.exitTime = exitTime;}
+    public void updateExitTime(LocalDateTime exitTime) { this.exitTime = exitTime; }
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/roomInMember/RoomInMemberApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/roomInMember/RoomInMemberApiController.java
@@ -1,11 +1,9 @@
 package com.mjuAppSW.joA.domain.roomInMember;
 
 import com.mjuAppSW.joA.common.dto.SuccessResponse;
-import com.mjuAppSW.joA.domain.roomInMember.dto.request.CheckRoomInMemberRequest;
 import com.mjuAppSW.joA.domain.roomInMember.dto.request.UpdateExpiredRequest;
 import com.mjuAppSW.joA.domain.roomInMember.dto.request.VoteRequest;
 import com.mjuAppSW.joA.domain.roomInMember.dto.response.RoomListResponse;
-import com.mjuAppSW.joA.domain.roomInMember.dto.response.UserInfoResponse;
 import com.mjuAppSW.joA.domain.roomInMember.dto.response.VoteResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -30,6 +28,7 @@ public class RoomInMemberApiController {
         @ApiResponse(responseCode = "200", description = "채팅방 목록 정보 반환"),
         @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다."),
         @ApiResponse(responseCode = "403", description = "M004: 정지된 계정입니다."),
+        @ApiResponse(responseCode = "403", description = "M014: 영구 정지된 계정입니다."),
         @ApiResponse(responseCode = "404", description = "RIM001: 채팅방을 찾을 수 없습니다."),
         @ApiResponse(responseCode = "500", description = "MG003: 메시지 복호화에 실패했습니다."),
     })
@@ -44,7 +43,8 @@ public class RoomInMemberApiController {
         @ApiResponse(responseCode = "200", description = "채팅방 연장 투표 저장 및 상대방 투표 유무 반환"),
         @ApiResponse(responseCode = "404", description = "R003: 방을 찾을 수 없습니다."),
         @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다."),
-        @ApiResponse(responseCode = "404", description = "RIM001: 채팅방을 찾을 수 없습니다.")
+        @ApiResponse(responseCode = "404", description = "RIM001: 채팅방을 찾을 수 없습니다."),
+        @ApiResponse(responseCode = "409", description = "RIM003: 이미 채팅방 연장에 대한 투표가 존재합니다."),
     })
     @PostMapping("/result")
     public ResponseEntity<SuccessResponse<VoteResponse>> saveVoteResult(@RequestBody @Valid VoteRequest request){
@@ -62,18 +62,6 @@ public class RoomInMemberApiController {
     @PatchMapping("/out")
     public ResponseEntity<Void> updateExpired(@RequestBody @Valid UpdateExpiredRequest request){
         roomInMemberService.updateExpired(request);
-        return ResponseEntity.ok().build();
-    }
-
-    @Operation(summary = "채팅방 생성 전 채팅방 유무 확인", description = "채팅 방 생성 전 이미 두 사용자의 채팅방이 존재하는지 확인 API")
-    @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "상태코드 반환"),
-        @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다."),
-        @ApiResponse(responseCode = "400", description = "RIM002: 이미 두 사용자의 채팅방이 존재합니다.")
-    })
-    @GetMapping("/existence")
-    public ResponseEntity<Void> checkRoomInMember(@RequestBody @Valid CheckRoomInMemberRequest request){
-        roomInMemberService.checkRoomInMember(request);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/roomInMember/RoomInMemberApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/roomInMember/RoomInMemberApiController.java
@@ -54,7 +54,7 @@ public class RoomInMemberApiController {
 
     @Operation(summary = "채팅방 퇴장", description = "채팅방 퇴장 API")
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "상태코드 반환"),
+        @ApiResponse(responseCode = "204", description = "HTTP 상태 코드 반환"),
         @ApiResponse(responseCode = "404", description = "R003: 방을 찾을 수 없습니다."),
         @ApiResponse(responseCode = "404", description = "M001: 사용자를 찾을 수 없습니다."),
         @ApiResponse(responseCode = "404", description = "RIM001: 채팅방을 찾을 수 없습니다.")
@@ -62,6 +62,6 @@ public class RoomInMemberApiController {
     @PatchMapping("/out")
     public ResponseEntity<Void> updateExpired(@RequestBody @Valid UpdateExpiredRequest request){
         roomInMemberService.updateExpired(request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/roomInMember/RoomInMemberRepository.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/roomInMember/RoomInMemberRepository.java
@@ -20,11 +20,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface RoomInMemberRepository extends JpaRepository<RoomInMember, Long> {
 
-    @Modifying
-    @Transactional
-    @Query("DELETE FROM RoomInMember rim WHERE rim.room = :room")
-    void deleteByRoom(@Param("room") Room room);
-
     @Query("SELECT rim FROM RoomInMember rim WHERE rim.room = :room AND rim.member = :member")
     Optional<RoomInMember> findByRoomAndMember(@Param("room") Room room, @Param("member") Member member);
 
@@ -33,9 +28,6 @@ public interface RoomInMemberRepository extends JpaRepository<RoomInMember, Long
 
     @Query("SELECT rim FROM RoomInMember rim WHERE rim.room = :room")
     List<RoomInMember> findByAllRoom(@Param("room") Room room);
-
-    @Query("SELECT rim From RoomInMember rim WHERE rim.room = :room AND NOT rim.member = :member")
-    Optional<RoomInMember> findByRoomAndExceptMember(@Param("room") Room room, @Param("member") Member member);
 
     @Query("SELECT rm FROM RoomInMember rm " +
             "WHERE rm.room.id IN (SELECT r.id FROM Room r " +
@@ -53,12 +45,9 @@ public interface RoomInMemberRepository extends JpaRepository<RoomInMember, Long
             "AND (mes.time IS NULL OR mes.time = (SELECT MAX(mes2.time) FROM Message mes2 WHERE mes2.member = :member AND mes2.room = :room))")
     Optional<RoomInfoIncludeMessageVO> findRoomInfoIncludeMessage(@Param("room") Room room, @Param("member") Member member);
 
-    @Query("SELECT rim.room AS room, rim.room.date AS date, m.name AS name, m.urlCode AS urlCode " +
-            "From RoomInMember rim " +
-            "LEFT JOIN Member m ON rim.member.id = m.id " +
-            "LEFT JOIN Room r ON rim.room.id = r.id " +
-            "WHERE rim.member = :member AND rim.room = :room ")
-    Optional<RoomInfoExceptMessageVO> findRoomInfoExceptMessage(@Param("room") Room room, @Param("member") Member member);
+    @Query("SELECT rim.room AS room, rim.room.date AS date, rim.member.name AS name, rim.member.urlCode AS urlCode " +
+        "From RoomInMember rim WHERE rim.member = :member AND rim.room = :room")
+    Optional<RoomInfoExceptMessageVO> findRoomInfoExceptMessageByRoomAndMember(@Param("room") Room room, @Param("member") Member member);
 
     @Query("SELECT rim FROM RoomInMember rim Where rim.room = :room")
     List<RoomInMember> findAllRoom(@Param("room") Room room);
@@ -69,9 +58,13 @@ public interface RoomInMemberRepository extends JpaRepository<RoomInMember, Long
     @Query("SELECT rim FROM RoomInMember rim Where rim.room = :room AND rim.member <> :member AND rim.expired = :expired")
     Optional<RoomInMember> checkOpponentExpired(@Param("room") Room room, @Param("member") Member member, @Param("expired") String expired);
 
-    @Query("SELECT rim.room.id AS roomId ,m.id AS memberId, m.name AS name, m.urlCode AS urlCode, m.bio AS bio " +
-            "From RoomInMember rim LEFT JOIN Member m ON rim.member.id = m.id " +
-            "WHERE rim.room = :room AND rim.member <> :member")
-    UserInfoVO getUserInfo(@Param("room") Room room, @Param("member") Member member);
+    @Query("SELECT rim.room.id AS roomId ,rim.member.id AS memberId, rim.member.name AS name, rim.member.urlCode AS urlCode, rim.member.bio AS bio " +
+            "FROM RoomInMember rim WHERE rim.room = :room AND rim.member <> :member")
+    Optional<UserInfoVO> findOpponentUserInfoByRoomAndMember(@Param("room") Room room, @Param("member") Member member);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM RoomInMember rim WHERE rim.room = :room")
+    void deleteByRoom(@Param("room") Room room);
 }
 

--- a/src/main/java/com/mjuAppSW/joA/domain/roomInMember/RoomInMemberService.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/roomInMember/RoomInMemberService.java
@@ -6,21 +6,19 @@ import com.mjuAppSW.joA.common.auth.MemberChecker;
 import com.mjuAppSW.joA.common.encryption.EncryptManager;
 import com.mjuAppSW.joA.domain.member.Member;
 import com.mjuAppSW.joA.domain.message.MessageRepository;
-import com.mjuAppSW.joA.domain.message.dto.vo.CurrentMessageVO;
 import com.mjuAppSW.joA.domain.message.exception.FailDecryptException;
 import com.mjuAppSW.joA.domain.room.Room;
 import com.mjuAppSW.joA.domain.room.RoomRepository;
 import com.mjuAppSW.joA.domain.room.exception.RoomNotFoundException;
-import com.mjuAppSW.joA.domain.roomInMember.dto.request.CheckRoomInMemberRequest;
 import com.mjuAppSW.joA.domain.roomInMember.dto.request.UpdateExpiredRequest;
 import com.mjuAppSW.joA.domain.roomInMember.dto.request.VoteRequest;
 import com.mjuAppSW.joA.domain.roomInMember.dto.response.RoomListResponse;
 import com.mjuAppSW.joA.domain.roomInMember.dto.response.VoteResponse;
+import com.mjuAppSW.joA.domain.roomInMember.exception.RoomInMemberAlreadyVoteResultException;
 import com.mjuAppSW.joA.domain.roomInMember.vo.RoomInfoExceptMessageVO;
 import com.mjuAppSW.joA.domain.roomInMember.vo.RoomInfoIncludeMessageVO;
 import com.mjuAppSW.joA.domain.roomInMember.vo.RoomInfoVO;
 import com.mjuAppSW.joA.domain.roomInMember.vo.RoomInfoExceptDateVO;
-import com.mjuAppSW.joA.domain.roomInMember.exception.RoomInMemberAlreadyExistedException;
 import com.mjuAppSW.joA.domain.roomInMember.exception.RoomInMemberNotFoundException;
 
 import jakarta.transaction.Transactional;
@@ -42,51 +40,42 @@ public class RoomInMemberService {
     private final MemberChecker memberChecker;
     private final EncryptManager encryptManager;
 
-    public void findByRoom(Long roomId){
-        Room room = roomRepository.findById(roomId).orElseThrow(RoomNotFoundException::new);
-
-        List<RoomInMember> roomInMemberList = roomInMemberRepository.findAllRoom(room);
-        for(RoomInMember roomInMember : roomInMemberList) {
-            if (roomInMember.getExpired().equals(NOT_EXIT)) {
-                throw new RoomInMemberAlreadyExistedException();
-            }
-        }
-    }
-
     public RoomListResponse getRoomList(Long memberId) {
-        Member member = memberChecker.findBySessionId(memberId);
-        memberChecker.checkStopped(member);
+        Member member = memberChecker.findFilterBySessionId(memberId);
 
-        List<RoomInMember> memberList = roomInMemberRepository.findByAllMember(member);
-        if (memberList.isEmpty()) {return RoomListResponse.of(new ArrayList<>());}
+        List<RoomInMember> myRoomInMemberList = roomInMemberRepository.findByAllMember(member);
+        if (myRoomInMemberList.isEmpty()) {return RoomListResponse.of(new ArrayList<>());}
 
         List<RoomInfoVO> roomWithoutMessageList = new ArrayList<>();
         List<RoomInfoVO> roomWithMessageList = new ArrayList<>();
-        for (RoomInMember rim : memberList) {
-            RoomInMember anotherRoomInMember = roomInMemberRepository.findByRoomAndExceptMember(rim.getRoom(), rim.getMember())
-                .orElseThrow(RoomInMemberNotFoundException::new);
-            RoomInfoExceptMessageVO roomInfoEMVO = roomInMemberRepository.findRoomInfoExceptMessage(anotherRoomInMember.getRoom(), anotherRoomInMember.getMember())
-                .orElseThrow(RoomInMemberNotFoundException::new);
-            CurrentMessageVO currentMessageVO = messageRepository.getCurrentMessageAndTime(anotherRoomInMember.getRoom())
-                .orElse(null);
-            Integer unCheckedMessage = messageRepository.countUnCheckedMessage(anotherRoomInMember.getRoom(), anotherRoomInMember.getMember());
-            if (roomInfoEMVO != null) {
-                if (currentMessageVO == null) {
-                    RoomInfoVO roomInfoVO = new RoomInfoVO(roomInfoEMVO.getRoom().getId(), roomInfoEMVO.getName(),
-                        roomInfoEMVO.getUrlCode(), null, roomInfoEMVO.getDate(), String.valueOf(unCheckedMessage));
-                    roomWithoutMessageList.add(roomInfoVO);
-                } else {
-                    String decryptedString = encryptManager.decrypt(currentMessageVO.getContent(), anotherRoomInMember.getRoom().getEncryptKey());
-                    if(decryptedString == null){
+        for (RoomInMember my : myRoomInMemberList) {
+            RoomInMember opponent = findOpponentByRoomAndMember(my.getRoom(), my.getMember());
+            RoomInfoExceptMessageVO roomInfoEMVO = findRoomInfoExceptMessageByRoomAndMember(opponent.getRoom(), opponent.getMember());
+            checkRoomInMemberWithMessages(roomWithoutMessageList, roomWithMessageList, opponent, roomInfoEMVO);
+        }
+        return RoomListResponse.of(combinedList(roomWithoutMessageList, roomWithMessageList));
+    }
+
+    private void checkRoomInMemberWithMessages(List<RoomInfoVO> roomWithoutMessageList, List<RoomInfoVO> roomWithMessageList,
+        RoomInMember opponent, RoomInfoExceptMessageVO roomInfoEMVO) {
+        Integer unCheckedMessage = messageRepository.countUnCheckedMessage(opponent.getRoom(), opponent.getMember());
+        messageRepository.getCurrentMessageAndTime(opponent.getRoom())
+            .ifPresentOrElse(
+                currentMessageVO -> {
+                    String decryptedString = encryptManager.decrypt(currentMessageVO.getContent(), opponent.getRoom().getEncryptKey());
+                    if (decryptedString == null) {
                         throw new FailDecryptException();
                     }
                     RoomInfoVO roomInfoVO = new RoomInfoVO(roomInfoEMVO.getRoom().getId(), roomInfoEMVO.getName(),
                         roomInfoEMVO.getUrlCode(), decryptedString, currentMessageVO.getTime(), String.valueOf(unCheckedMessage));
                     roomWithMessageList.add(roomInfoVO);
+                },
+                () -> {
+                    RoomInfoVO roomInfoVO = new RoomInfoVO(roomInfoEMVO.getRoom().getId(), roomInfoEMVO.getName(),
+                        roomInfoEMVO.getUrlCode(), null, roomInfoEMVO.getDate(), String.valueOf(unCheckedMessage));
+                    roomWithoutMessageList.add(roomInfoVO);
                 }
-            }
-        }
-        return RoomListResponse.of(combinedList(roomWithoutMessageList, roomWithMessageList));
+            );
     }
 
     private List<RoomInfoExceptDateVO> combinedList(List<RoomInfoVO> roomWithoutMessageList, List<RoomInfoVO> roomWithMessageList){
@@ -108,9 +97,8 @@ public class RoomInMemberService {
     }
 
     public RoomInfoExceptDateVO getUpdateRoom(Room room, Member member){
-        RoomInMember roomInMember = roomInMemberRepository.findByRoomAndMember(room, member).orElseThrow(RoomInMemberNotFoundException::new);
-        RoomInfoIncludeMessageVO rlr = roomInMemberRepository.findRoomInfoIncludeMessage(roomInMember.getRoom(), roomInMember.getMember())
-            .orElseThrow(RoomInMemberNotFoundException::new);
+        RoomInMember roomInMember = findByRoomAndMember(room, member);
+        RoomInfoIncludeMessageVO rlr = findRoomInfoIncludeMessageByRoomAndMember(roomInMember.getRoom(), roomInMember.getMember());
         Integer unCheckedMessageCount = messageRepository.countUnCheckedMessage(roomInMember.getRoom(), roomInMember.getMember());
 
         String decryptedString = encryptManager.decrypt(rlr.getContent(), rlr.getRoom().getEncryptKey());
@@ -122,7 +110,7 @@ public class RoomInMemberService {
 
     @Transactional
     public void createRoom(Long roomId, String[] idArr){
-        Room room = roomRepository.findById(roomId).orElseThrow(RoomNotFoundException::new);
+        Room room = findByRoomId(roomId);
 
         for(String memberId : idArr){
             Member member = memberChecker.findById(Long.parseLong(memberId));
@@ -130,7 +118,7 @@ public class RoomInMemberService {
                 .room(room)
                 .member(member)
                 .expired(NOT_EXIT)
-                .result(DISAPPROVE_OR_BEFORE_VOTE)
+                .result(BEFORE_VOTE)
                 .build();
 
             roomInMemberRepository.save(roomInMember);
@@ -138,68 +126,89 @@ public class RoomInMemberService {
     }
 
     @Transactional
-    public VoteResponse saveVoteResult(VoteRequest request){
-        Room room = roomRepository.findById(request.getRoomId()).orElseThrow(RoomNotFoundException::new);
+    public VoteResponse saveVoteResult(VoteRequest request) {
+        Room room = findByRoomId(request.getRoomId());
         Member member = memberChecker.findBySessionId(request.getMemberId());
-        RoomInMember roomInMember = roomInMemberRepository.findByRoomAndMember(room, member).orElseThrow(RoomInMemberNotFoundException::new);
+        RoomInMember roomInMember = findByRoomAndMember(room, member);
+        if (roomInMember.getResult().equals(APPROVE_VOTE) || roomInMember.getResult().equals(DISAPPROVE_VOTE)) {
+            throw new RoomInMemberAlreadyVoteResultException();
+        }
 
         roomInMember.saveResult(request.getResult());
-        RoomInMember anotherRoomInMember = roomInMemberRepository.findByRoomAndExceptMember(room, member).orElseThrow(RoomInMemberNotFoundException::new);
-        return VoteResponse.of(anotherRoomInMember.getRoom().getId(), anotherRoomInMember.getMember().getId(), anotherRoomInMember.getResult());
-    }
 
-    public void checkRoomInMember(CheckRoomInMemberRequest request){
-        Member member1 = memberChecker.findBySessionId(request.getMemberId1());
-        Member member2 = memberChecker.findById(request.getMemberId2());
-        List<RoomInMember> getRoomInMembers = roomInMemberRepository.checkRoomInMember(member1, member2);
-        for(RoomInMember rim : getRoomInMembers){
-            if(rim.getExpired().equals(NOT_EXIT)){throw new RoomInMemberAlreadyExistedException();}
-        }
+        RoomInMember anotherRoomInMember = findOpponentByRoomAndMember(room, member);
+        return VoteResponse.of(anotherRoomInMember.getRoom().getId(), anotherRoomInMember.getMember().getId(),
+            anotherRoomInMember.getResult());
     }
 
     @Transactional
     public void updateExpired(UpdateExpiredRequest request) {
-        Room room = roomRepository.findById(request.getRoomId()).orElseThrow(RoomNotFoundException::new);
+        Room room = findByRoomId(request.getRoomId());
         Member member = memberChecker.findBySessionId(request.getMemberId());
-        RoomInMember roomInMember = roomInMemberRepository.findByRoomAndMember(room, member).orElseThrow(RoomInMemberNotFoundException::new);
+        RoomInMember roomInMember = findByRoomAndMember(room, member);
 
-        roomInMember.updateExpired(request.getExpired());
+        roomInMember.updateExpired(EXIT);
     }
 
     @Transactional
     public void updateEntryTime(String sRoomId, String sMemberId){
-        Room room = roomRepository.findById(Long.parseLong(sRoomId)).orElseThrow(RoomNotFoundException::new);
+        Room room = findByRoomId(Long.parseLong(sRoomId));
         Member member = memberChecker.findById(Long.parseLong(sMemberId));
-        RoomInMember roomInMember = roomInMemberRepository.findByRoomAndMember(room, member).orElseThrow(RoomInMemberNotFoundException::new);
+        RoomInMember roomInMember = findByRoomAndMember(room, member);
 
         roomInMember.updateEntryTime(LocalDateTime.now());
     }
 
     @Transactional
     public void updateExitTime(String sRoomId, String sMemberId){
-        Room room = roomRepository.findById(Long.parseLong(sRoomId)).orElseThrow(RoomNotFoundException::new);
+        Room room = findByRoomId(Long.parseLong(sRoomId));
         Member member = memberChecker.findById(Long.parseLong(sMemberId));
-        RoomInMember roomInMember = roomInMemberRepository.findByRoomAndMember(room, member).orElseThrow(RoomInMemberNotFoundException::new);
+        RoomInMember roomInMember = findByRoomAndMember(room, member);
 
         roomInMember.updateExitTime(LocalDateTime.now());
     }
 
     public Boolean checkExpired(Long roomId, Long memberId){
-        Room room = roomRepository.findById(roomId).orElseThrow(RoomNotFoundException::new);
+        Room room = findByRoomId(roomId);
         Member member = memberChecker.findById(memberId);
-        RoomInMember roomInMember = roomInMemberRepository.findOpponentByRoomAndMember(room, member).orElseThrow(RoomInMemberNotFoundException::new);
+        RoomInMember roomInMember = findOpponentByRoomAndMember(room, member);
 
         if(roomInMember.getExpired().equals(NOT_EXIT)){return true;}
         return false;
     }
 
     public Boolean checkIsWithDrawal(Long roomId, Long memberId){
-        Room room = roomRepository.findById(roomId).orElseThrow(RoomNotFoundException::new);
+        Room room = findByRoomId(roomId);
         Member member = memberChecker.findById(memberId);
-        RoomInMember rim = roomInMemberRepository.findOpponentByRoomAndMember(room, member).orElseThrow(RoomInMemberNotFoundException::new);
+        RoomInMember rim = findOpponentByRoomAndMember(room, member);
 
         Member opponentMember = memberChecker.findById(rim.getMember().getId());
         if (opponentMember != null) return true;
         return false;
+    }
+
+    private Room findByRoomId(Long roomId){
+        return roomRepository.findById(roomId)
+            .orElseThrow(RoomNotFoundException::new);
+    }
+
+    private RoomInMember findOpponentByRoomAndMember(Room room, Member member){
+        return roomInMemberRepository.findOpponentByRoomAndMember(room, member)
+            .orElseThrow(RoomInMemberNotFoundException::new);
+    }
+
+    private RoomInfoExceptMessageVO findRoomInfoExceptMessageByRoomAndMember(Room room, Member member){
+        return roomInMemberRepository.findRoomInfoExceptMessageByRoomAndMember(room, member)
+            .orElseThrow(RoomInMemberNotFoundException::new);
+    }
+
+    private RoomInMember findByRoomAndMember(Room room, Member member){
+        return roomInMemberRepository.findByRoomAndMember(room, member)
+            .orElseThrow(RoomInMemberNotFoundException::new);
+    }
+
+    private RoomInfoIncludeMessageVO findRoomInfoIncludeMessageByRoomAndMember(Room room, Member member){
+        return roomInMemberRepository.findRoomInfoIncludeMessage(room, member)
+            .orElseThrow(RoomInMemberNotFoundException::new);
     }
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/roomInMember/dto/request/UpdateExpiredRequest.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/roomInMember/dto/request/UpdateExpiredRequest.java
@@ -1,19 +1,19 @@
 package com.mjuAppSW.joA.domain.roomInMember.dto.request;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @Schema(description = "채팅방 퇴장 Request")
+@RequiredArgsConstructor
+@NoArgsConstructor(force = true)
 public class UpdateExpiredRequest {
     @NotNull
-    private Long roomId;
+    private final Long roomId;
     @NotNull
-    private Long memberId;
-    @NotNull
-    private String expired;
+    private final Long memberId;
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/roomInMember/dto/request/VoteRequest.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/roomInMember/dto/request/VoteRequest.java
@@ -3,14 +3,18 @@ package com.mjuAppSW.joA.domain.roomInMember.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @Schema(description = "채팅방 연장 투표 저장 및 상대방 투표 유무 확인 Request")
+@RequiredArgsConstructor
+@NoArgsConstructor(force = true)
 public class VoteRequest {
     @NotNull
-    private Long roomId;
+    private final Long roomId;
     @NotNull
-    private Long memberId;
+    private final Long memberId;
     @NotNull
-    private String result;
+    private final String result;
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/roomInMember/dto/response/RoomListResponse.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/roomInMember/dto/response/RoomListResponse.java
@@ -5,18 +5,17 @@ import java.util.List;
 import com.mjuAppSW.joA.domain.roomInMember.vo.RoomInfoExceptDateVO;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @Schema(description = "채팅방 목록 페이지 정보 조회 Response")
+@Builder(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class RoomListResponse {
-	List<RoomInfoExceptDateVO> roomListVOs;
-
-	@Builder
-	public RoomListResponse(List<RoomInfoExceptDateVO> roomListVOs){
-		this.roomListVOs = roomListVOs;
-	}
+	private final List<RoomInfoExceptDateVO> roomListVOs;
 
 	public static RoomListResponse of(List<RoomInfoExceptDateVO> roomListVOs) {
 		return RoomListResponse.builder()

--- a/src/main/java/com/mjuAppSW/joA/domain/roomInMember/dto/response/UserInfoResponse.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/roomInMember/dto/response/UserInfoResponse.java
@@ -1,22 +1,19 @@
 package com.mjuAppSW.joA.domain.roomInMember.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @Schema(description = "채팅방 입장시 상대방 정보 조회 Response")
+@Builder(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class UserInfoResponse {
-	private String name;
-	private String urlCode;
-	private String bio;
-
-	@Builder
-	public UserInfoResponse(String name, String urlCode, String bio) {
-		this.name = name;
-		this.urlCode = urlCode;
-		this.bio = bio;
-	}
+	private final String name;
+	private final String urlCode;
+	private final String bio;
 
 	public static UserInfoResponse of(String name, String urlCode, String bio) {
 		return UserInfoResponse.builder()

--- a/src/main/java/com/mjuAppSW/joA/domain/roomInMember/dto/response/VoteResponse.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/roomInMember/dto/response/VoteResponse.java
@@ -1,23 +1,20 @@
 package com.mjuAppSW.joA.domain.roomInMember.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 @Getter
 @Schema(description = "방 연장 투표 후 상대방의 투표 유무 Response")
+@Builder(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public class VoteResponse {
-    private Long roomId;
-    private Long memberId;
-    @Schema(description = "상대방의 result 결과 0 -> 찬성 / 1 -> 반대 혹은 투표하지 않음")
-    private String result;
-
-    @Builder
-    public VoteResponse(Long roomId, Long memberId, String result) {
-        this.roomId = roomId;
-        this.memberId = memberId;
-        this.result = result;
-    }
+    private final Long roomId;
+    private final Long memberId;
+    @Schema(description = "상대방의 투표 결과 [0 -> 찬성, 1 -> 반대, 2 -> 투표하지 않음]")
+    private final String result;
 
     public static VoteResponse of(Long roomId, Long memberId, String result) {
         return VoteResponse.builder()

--- a/src/main/java/com/mjuAppSW/joA/domain/roomInMember/exception/RoomInMemberAlreadyVoteResultException.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/roomInMember/exception/RoomInMemberAlreadyVoteResultException.java
@@ -1,0 +1,10 @@
+package com.mjuAppSW.joA.domain.roomInMember.exception;
+
+import com.mjuAppSW.joA.common.exception.BusinessException;
+import com.mjuAppSW.joA.common.exception.ErrorCode;
+
+public class RoomInMemberAlreadyVoteResultException extends BusinessException {
+	public RoomInMemberAlreadyVoteResultException(){
+		super(ErrorCode.RIM_ALREADY_VOTE_RESULT);
+	}
+}


### PR DESCRIPTION
# 요약
- Presentation Layer에서는 URI 수정, GetMapping @RequestParam으로 변경, DTO 가이드 라인에 맞게 수정, WebSocket Method명 변경 등을 하였습니다.
- Service Layer에서는 일부 메소드를 람다식 표현으로 수정  및 추가, 클린코드를 작성하고자 메소드를 세분화 하였습니다.
- Domain에 불필요한 어노테이션을 제거하였습니다.
- API 응답에 Body가 없을 경우 204로 반환하였습니다.
# 체크 리스트
이 PR에는:

- [ ] 새로운 테스트의 추가 여부
- [x] 공개 API의 변경 여부
- [ ] 설계 문서의 포함 여부

# 본문
API URI 수정, Swagger 그룹명 변경 및 주석처리 삭제 #14에서 주신 피드백을 바탕으로 수정 및 리팩토링을 하였습니다.
Room은 채팅방 정보 및 채팅방 생성에 필요한 조건을 관리하는 API, RoomInMember는 채팅방 사용자에 관한 API로 역할과 책임을 분리하였습니다.

Service Layer에서 클린코드 작성을 위해, 한 메소드가 갖는 책임을 최소화 하였습니다.
또한 람다식 표현을 사용하여 코드를 간결화 하였습니다.

추가적으로 API 가이드 라인에 맞추어 DTO를 통일화 하였습니다.