### PR TITLE
중복 코드 제거 및 쿼리 수정

### DIFF
--- a/src/main/java/com/mjuAppSW/joA/domain/member/controller/InfoApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/member/controller/InfoApiController.java
@@ -161,7 +161,7 @@ public class InfoApiController {
         @ApiResponse(responseCode = "404", description = "R003: 방을 찾을 수 없습니다."),
         @ApiResponse(responseCode = "404", description = "RIM001: 채팅방을 찾을 수 없습니다.")
     })
-    @GetMapping("/userinfo")
+    @GetMapping("/chatting-page")
     public ResponseEntity<SuccessResponse<ChattingPageResponse>> getUserInfo(@RequestParam("roomId") Long roomId, @RequestParam("memberId") Long memberId){
         return SuccessResponse.of(infoService.getChattingPage(roomId, memberId))
             .asHttp(HttpStatus.OK);

--- a/src/main/java/com/mjuAppSW/joA/domain/member/controller/InfoApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/member/controller/InfoApiController.java
@@ -163,7 +163,7 @@ public class InfoApiController {
     })
     @GetMapping("/userinfo")
     public ResponseEntity<SuccessResponse<ChattingPageResponse>> getUserInfo(@RequestParam("roomId") Long roomId, @RequestParam("memberId") Long memberId){
-        return SuccessResponse.of(infoService.getChattingListPage(roomId, memberId))
+        return SuccessResponse.of(infoService.getChattingPage(roomId, memberId))
             .asHttp(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/member/controller/InfoApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/member/controller/InfoApiController.java
@@ -163,7 +163,7 @@ public class InfoApiController {
     })
     @GetMapping("/userinfo")
     public ResponseEntity<SuccessResponse<ChattingPageResponse>> getUserInfo(@RequestParam("roomId") Long roomId, @RequestParam("memberId") Long memberId){
-        return SuccessResponse.of(infoService.getUserInfo(roomId, memberId))
+        return SuccessResponse.of(infoService.getChattingListPage(roomId, memberId))
             .asHttp(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/member/service/InfoService.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/member/service/InfoService.java
@@ -51,7 +51,7 @@ public class InfoService {
         return MyPageResponse.of(member, todayHeart, totalHeart, voteTop3);
     }
 
-    public ChattingPageResponse getChattingListPage(Long roomId, Long memberId){
+    public ChattingPageResponse getChattingPage(Long roomId, Long memberId){
         Room room = roomService.findByRoomId(roomId);
         Member member = memberService.getBySessionId(memberId);
         RoomInMember roomInMember = roomInMemberService.findByRoomAndMember(room, member);

--- a/src/main/java/com/mjuAppSW/joA/domain/member/service/InfoService.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/member/service/InfoService.java
@@ -9,15 +9,12 @@ import com.mjuAppSW.joA.domain.member.dto.response.MyPageResponse;
 import com.mjuAppSW.joA.domain.member.dto.request.PictureRequest;
 import com.mjuAppSW.joA.domain.member.dto.response.SettingPageResponse;
 import com.mjuAppSW.joA.domain.member.dto.response.ChattingPageResponse;
-import com.mjuAppSW.joA.domain.member.exception.MemberNotFoundException;
 import com.mjuAppSW.joA.domain.member.infrastructure.ImageUploader;
 import com.mjuAppSW.joA.domain.member.vo.UserInfoVO;
 import com.mjuAppSW.joA.domain.room.Room;
-import com.mjuAppSW.joA.domain.room.RoomRepository;
-import com.mjuAppSW.joA.domain.room.exception.RoomNotFoundException;
+import com.mjuAppSW.joA.domain.room.RoomService;
 import com.mjuAppSW.joA.domain.roomInMember.RoomInMember;
-import com.mjuAppSW.joA.domain.roomInMember.RoomInMemberRepository;
-import com.mjuAppSW.joA.domain.roomInMember.exception.RoomInMemberNotFoundException;
+import com.mjuAppSW.joA.domain.roomInMember.RoomInMemberService;
 import com.mjuAppSW.joA.domain.vote.VoteRepository;
 import com.mjuAppSW.joA.domain.member.dto.response.VotePageResponse;
 import com.mjuAppSW.joA.domain.member.dto.response.LocationPageResponse;
@@ -32,11 +29,12 @@ import org.springframework.stereotype.Service;
 public class InfoService {
 
     private final MemberService memberService;
+    private final RoomService roomService;
+    private final RoomInMemberService roomInMemberService;
     private final ImageUploader imageUploader;
     private final HeartRepository heartRepository;
     private final VoteRepository voteRepository;
-    private final RoomRepository roomRepository;
-    private final RoomInMemberRepository roomInMemberRepository;
+
 
     public SettingPageResponse getSettingPage(Long sessionId) {
         Member member = memberService.getNormalBySessionId(sessionId);
@@ -53,12 +51,12 @@ public class InfoService {
         return MyPageResponse.of(member, todayHeart, totalHeart, voteTop3);
     }
 
-    public ChattingPageResponse getUserInfo(Long roomId, Long memberId){
-        Room room = findByRoomId(roomId);
+    public ChattingPageResponse getChattingListPage(Long roomId, Long memberId){
+        Room room = roomService.findByRoomId(roomId);
         Member member = memberService.getBySessionId(memberId);
-        RoomInMember roomInMember = findByRoomAndMember(room, member);
+        RoomInMember roomInMember = roomInMemberService.findByRoomAndMember(room, member);
 
-        UserInfoVO userInfoVO = findOpponentUserInfoByRoomAndMember(roomInMember.getRoom(), roomInMember.getMember());
+        UserInfoVO userInfoVO = roomInMemberService.findOpponentUserInfoByRoomAndMember(roomInMember.getRoom(), roomInMember.getMember());
         return ChattingPageResponse.of(userInfoVO.getName(), userInfoVO.getUrlCode(), userInfoVO.getBio());
     }
 
@@ -99,21 +97,6 @@ public class InfoService {
             imageUploader.delete(member.getUrlCode());
             member.deleteUrlCode();
         }
-    }
-
-    private Room findByRoomId(Long roomId){
-        return roomRepository.findById(roomId)
-            .orElseThrow(RoomNotFoundException::new);
-    }
-
-    private RoomInMember findByRoomAndMember(Room room, Member member){
-        return roomInMemberRepository.findByRoomAndMember(room, member)
-            .orElseThrow(RoomInMemberNotFoundException::new);
-    }
-
-    private UserInfoVO findOpponentUserInfoByRoomAndMember(Room room, Member member){
-        return roomInMemberRepository.findOpponentUserInfoByRoomAndMember(room, member)
-            .orElseThrow(MemberNotFoundException::new);
     }
 
     private boolean isNotBasicPicture(String urlCode) {

--- a/src/main/java/com/mjuAppSW/joA/domain/report/message/MessageReportService.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/report/message/MessageReportService.java
@@ -13,8 +13,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
 import com.mjuAppSW.joA.domain.message.Message;
-import com.mjuAppSW.joA.domain.message.MessageRepository;
-import com.mjuAppSW.joA.domain.message.exception.MessageNotFoundException;
+import com.mjuAppSW.joA.domain.message.MessageService;
 import com.mjuAppSW.joA.domain.report.ReportCategory;
 import com.mjuAppSW.joA.domain.report.ReportCategoryRepository;
 import com.mjuAppSW.joA.domain.report.message.dto.request.ReportRequest;
@@ -30,15 +29,14 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class MessageReportService {
-
-    private final MessageReportRepository messageReportRepository;
-    private final MessageRepository messageRepository;
-    private final ReportCategoryRepository reportCategoryRepository;
     private final MemberService memberService;
+    private final MessageService messageService;
+    private final MessageReportRepository messageReportRepository;
+    private final ReportCategoryRepository reportCategoryRepository;
 
     @Transactional
     public void messageReport(ReportRequest request, LocalDateTime messageReportDate){
-        Message message = findByMessageId(request.getMessageId());
+        Message message = messageService.findByMessageId(request.getMessageId());
         ReportCategory reportCategory = findByCategoryId(request.getCategoryId());
         checkExistedReportMessage(message);
 
@@ -61,10 +59,6 @@ public class MessageReportService {
         messageReportRepository.delete(messageReport);
     }
 
-    private Message findByMessageId(Long messageId){
-        return messageRepository.findById(messageId)
-            .orElseThrow(MessageNotFoundException::new);
-    }
     private MessageReport findByMessageReportId(Long messageReportId){
         return messageReportRepository.findById(messageReportId)
             .orElseThrow(MessageReportNotFoundException::new);

--- a/src/main/java/com/mjuAppSW/joA/domain/room/RoomService.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/room/RoomService.java
@@ -148,7 +148,7 @@ public class RoomService {
         }
     }
 
-    private Room findByRoomId(Long roomId){
+    public Room findByRoomId(Long roomId){
         return roomRepository.findById(roomId)
             .orElseThrow(RoomNotFoundException::new);
     }

--- a/src/main/java/com/mjuAppSW/joA/domain/roomInMember/RoomInMemberRepository.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/roomInMember/RoomInMemberRepository.java
@@ -35,15 +35,12 @@ public interface RoomInMemberRepository extends JpaRepository<RoomInMember, Long
         "AND r.id IN (SELECT rm2.room.id FROM RoomInMember rm2 WHERE rm2.member = :member2))")
     List<RoomInMember> checkRoomInMember(@Param("member1") Member member1, @Param("member2") Member member2);
 
-    @Query("SELECT rim.room AS room, rim.room.date AS date, m.name AS name, m.urlCode AS urlCode, mes.content AS content " +
-        "FROM RoomInMember rim " +
-        "LEFT JOIN Member m ON rim.member.id = m.id " +
-        "LEFT JOIN Room r ON rim.room.id = r.id " +
-        "LEFT JOIN Message mes ON rim.member = mes.member AND rim.room = mes.room " +
-        "WHERE rim.member = :member AND rim.room = :room " +
-        "AND (mes.content IS NULL OR mes.content IS NOT NULL) " +
-        "AND (mes.time IS NULL OR mes.time = (SELECT MAX(mes2.time) FROM Message mes2 WHERE mes2.member = :member AND mes2.room = :room))")
-    Optional<RoomInfoIncludeMessageVO> findRoomInfoIncludeMessage(@Param("room") Room room, @Param("member") Member member);
+    @Query("SELECT rim.room AS room, rim.room.date AS date, rim.member.name AS name, rim.member.urlCode AS urlCode, mes.content AS content " +
+            "FROM RoomInMember rim " +
+            "LEFT JOIN Message mes ON rim.member = mes.member AND rim.room = mes.room " +
+            "WHERE rim.member = :member AND rim.room = :room " +
+            "ORDER BY mes.time DESC")
+    List<RoomInfoIncludeMessageVO> findRoomInfoIncludeMessage(@Param("room") Room room, @Param("member") Member member);
 
     @Query("SELECT rim.room AS room, rim.room.date AS date, rim.member.name AS name, rim.member.urlCode AS urlCode " +
         "From RoomInMember rim WHERE rim.member = :member AND rim.room = :room")


### PR DESCRIPTION
# 요약
- 서비스 계층의 private 메소드를 각 서비스 계층에 맞게 public으로 전환하여 중복되는 코드들을 삭제하였습니다.
- InfoService의 메소드명을 수정하였습니다.
- 채팅방 목록 페이지에서 최근 메시지가 업데이트 될 때, 마이크로초까지 일치하는 경우 query의 기대값이 1이 아니라는 에러를 수정하였습니다.

# 체크 리스트
이 PR에는:

- [ ] 새로운 테스트의 추가 여부
- [x] 공개 API의 변경 여부
- [ ] 설계 문서의 포함 여부

# 본문
채팅방 목록 페이지(웹소켓 /ws?memberId=?)일 때, 최근 메시지를 업데이트 되는 과정에서 저장된 메시지의 시간이 마이크로초(ex, 01:13:15.000000)까지 일치하는 경우 query의 기대값이 1이 아니라는 에러를 발견하였습니다.

기존 query의 문제점은 메시지가 존재할 때 가장 최근에 저장된 메시지를 가져오는 조건이었습니다. 이 조건을 다음과 같이 수정하였습니다.

쿼리의 조건을 시간 기준으로 내림차순으로 정렬하여 List로 반환하고, service 계층에서 list의 0번째 값을 반환하도록 하였습니다. 혹시 이와 다른 좋은 방법이 있다면 의견 남겨주세요!