### PR TITLE
회원 정지 기간 오류 수정

### DIFF
--- a/src/main/java/com/mjuAppSW/joA/JProjectApplication.java
+++ b/src/main/java/com/mjuAppSW/joA/JProjectApplication.java
@@ -2,8 +2,6 @@ package com.mjuAppSW.joA;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.domain.EntityScan;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 

--- a/src/main/java/com/mjuAppSW/joA/common/constant/Constants.java
+++ b/src/main/java/com/mjuAppSW/joA/common/constant/Constants.java
@@ -71,8 +71,8 @@ public class Constants {
         public static int STEP_1_REPORT_COUNT = 5;
         public static int STEP_2_REPORT_COUNT = 10;
         public static int STEP_3_REPORT_COUNT = 15;
-        public static int STEP_1_DATE = 2;
-        public static int STEP_2_DATE = 8;
+        public static int STEP_1_DATE = 1;
+        public static int STEP_2_DATE = 7;
     }
 
     public static class SlackService{

--- a/src/main/java/com/mjuAppSW/joA/domain/heart/dto/HeartRequest.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/heart/dto/HeartRequest.java
@@ -17,6 +17,8 @@ public class HeartRequest {
     @Schema(description = "하트를 받는 사용자의 pk")
     @NotNull
     private final Long takeId;
+
+    // FIXME : 불필요한 data
     @Schema(description = "실명 여부(실명일 시 true)")
     @NotNull
     private final Boolean named;


### PR DESCRIPTION
# 요약
- 회원 정지 정책(1단계 - 1일, 2단계 - 7일)보다 실제로 하루 더 정지되는 오류를 수정하였습니다.

# 체크 리스트
이 PR에는:

- [ ] 새로운 테스트의 추가 여부
- [ ] 공개 API의 변경 여부
- [ ] 설계 문서의 포함 여부