### PR TITLE
Slack 비동기로 변경, 메시지 신고 수정, VO 패키지 이동

### DIFF
--- a/src/main/java/com/mjuAppSW/joA/domain/message/dto/request/ReportRequest.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/message/dto/request/ReportRequest.java
@@ -15,4 +15,5 @@ public class ReportRequest {
     private final Long messageId;
     @NotNull
     private final Long categoryId;
+    private final String content;
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/message/dto/response/MessageResponse.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/message/dto/response/MessageResponse.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.List;
 
-import com.mjuAppSW.joA.domain.message.dto.vo.MessageVO;
+import com.mjuAppSW.joA.domain.message.vo.MessageVO;
 
 @Getter
 @Schema(description = "채팅 목록 Response")

--- a/src/main/java/com/mjuAppSW/joA/domain/message/repository/MessageRepository.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/message/repository/MessageRepository.java
@@ -1,6 +1,6 @@
 package com.mjuAppSW.joA.domain.message.repository;
 
-import com.mjuAppSW.joA.domain.message.dto.vo.CurrentMessageVO;
+import com.mjuAppSW.joA.domain.message.vo.CurrentMessageVO;
 import com.mjuAppSW.joA.domain.message.entity.Message;
 import com.mjuAppSW.joA.domain.room.entity.Room;
 import com.mjuAppSW.joA.domain.member.entity.Member;

--- a/src/main/java/com/mjuAppSW/joA/domain/message/service/MessageService.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/message/service/MessageService.java
@@ -5,7 +5,7 @@ import static com.mjuAppSW.joA.common.constant.Constants.Message.*;
 
 import com.mjuAppSW.joA.domain.member.service.MemberQueryService;
 import com.mjuAppSW.joA.domain.message.dto.response.MessageResponse;
-import com.mjuAppSW.joA.domain.message.dto.vo.MessageVO;
+import com.mjuAppSW.joA.domain.message.vo.MessageVO;
 import com.mjuAppSW.joA.domain.message.exception.FailDecryptException;
 import com.mjuAppSW.joA.domain.message.exception.FailEncryptException;
 import com.mjuAppSW.joA.domain.room.entity.Room;

--- a/src/main/java/com/mjuAppSW/joA/domain/message/vo/CurrentMessageVO.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/message/vo/CurrentMessageVO.java
@@ -1,4 +1,4 @@
-package com.mjuAppSW.joA.domain.message.dto.vo;
+package com.mjuAppSW.joA.domain.message.vo;
 
 import java.util.Date;
 

--- a/src/main/java/com/mjuAppSW/joA/domain/message/vo/MessageVO.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/message/vo/MessageVO.java
@@ -1,4 +1,4 @@
-package com.mjuAppSW.joA.domain.message.dto.vo;
+package com.mjuAppSW.joA.domain.message.vo;
 
 import lombok.Data;
 

--- a/src/main/java/com/mjuAppSW/joA/domain/messageReport/service/MessageReportService.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/messageReport/service/MessageReportService.java
@@ -41,7 +41,7 @@ public class MessageReportService {
         ReportCategory reportCategory = reportCategoryQueryService.getBy(request.getCategoryId());
         messageReportQueryService.validateNoExistedMessageReport(message);
 
-        MessageReport messageReport = create(message, reportCategory, messageReportDate);
+        MessageReport messageReport = create(message, reportCategory, request.getContent(), messageReportDate);
 
         messageReportRepository.save(messageReport);
 
@@ -49,11 +49,11 @@ public class MessageReportService {
         member.addReportCount();
     }
 
-    private MessageReport create(Message message, ReportCategory reportCategory, LocalDateTime messageReportDate){
+    private MessageReport create(Message message, ReportCategory reportCategory, String content, LocalDateTime messageReportDate){
         return MessageReport.builder()
             .message_id(message)
             .category_id(reportCategory)
-            .content(message.getContent())
+            .content(content)
             .date(messageReportDate)
             .build();
     }

--- a/src/main/java/com/mjuAppSW/joA/domain/roomInMember/controller/RoomInMemberApiController.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/roomInMember/controller/RoomInMemberApiController.java
@@ -36,8 +36,8 @@ public class RoomInMemberApiController {
         @ApiResponse(responseCode = "404-2", description = "RIM001: 사용자와 연결된 채팅방을 찾을 수 없습니다.", content = @Content(schema = @Schema(hidden = true))),
         @ApiResponse(responseCode = "500", description = "MG003: 메시지 복호화에 실패했습니다.", content = @Content(schema = @Schema(hidden = true))),
     })
-    @GetMapping("/{memberId}")
-    public ResponseEntity<SuccessResponse<RoomListResponse>> getChattingRoomListPage(@PathVariable("memberId") Long memberId){
+    @GetMapping
+    public ResponseEntity<SuccessResponse<RoomListResponse>> getChattingRoomListPage(@RequestParam("memberId") Long memberId){
         return SuccessResponse.of(roomInMemberService.getChattingRoomListPage(memberId))
             .asHttp(HttpStatus.OK);
     }

--- a/src/main/java/com/mjuAppSW/joA/domain/roomInMember/service/RoomInMemberService.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/roomInMember/service/RoomInMemberService.java
@@ -6,7 +6,7 @@ import static com.mjuAppSW.joA.common.constant.Constants.RoomInMember.*;
 
 import com.mjuAppSW.joA.domain.member.dto.response.ChattingPageResponse;
 import com.mjuAppSW.joA.domain.member.service.MemberQueryService;
-import com.mjuAppSW.joA.domain.message.dto.vo.CurrentMessageVO;
+import com.mjuAppSW.joA.domain.message.vo.CurrentMessageVO;
 import com.mjuAppSW.joA.domain.message.exception.FailDecryptException;
 import com.mjuAppSW.joA.domain.message.repository.MessageRepository;
 import com.mjuAppSW.joA.domain.room.entity.Room;

--- a/src/main/java/com/mjuAppSW/joA/slack/SlackServiceUtil.java
+++ b/src/main/java/com/mjuAppSW/joA/slack/SlackServiceUtil.java
@@ -9,11 +9,10 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.mjuAppSW.joA.slack.vo.HttpServletRequestVO;
 import com.slack.api.model.Attachment;
 import com.slack.api.model.block.LayoutBlock;
 import com.slack.api.model.block.composition.TextObject;
-
-import jakarta.servlet.http.HttpServletRequest;
 
 public class SlackServiceUtil {
 
@@ -26,7 +25,7 @@ public class SlackServiceUtil {
 		return attachments;
 	}
 
-	public static List<LayoutBlock> createProdErrorMessage(HttpServletRequest request, Exception exception) {
+	public static List<LayoutBlock> createProdErrorMessage(HttpServletRequestVO request, Exception exception) {
 		StackTraceElement[] stacks = exception.getStackTrace();
 
 		List<LayoutBlock> layoutBlockList = new ArrayList<>();
@@ -34,8 +33,8 @@ public class SlackServiceUtil {
 		List<TextObject> sectionInFields = new ArrayList<>();
 		sectionInFields.add(markdownText(ERROR_MESSAGE + exception.getMessage()));
 		sectionInFields.add(markdownText(ERROR_STACK + exception));
-		sectionInFields.add(markdownText(ERROR_URI + request.getRequestURL()));
-		sectionInFields.add(markdownText(ERROR_METHOD + request.getMethod()));
+		sectionInFields.add(markdownText(ERROR_URI + request.getHttpServletRequest().getRequestURL()));
+		sectionInFields.add(markdownText(ERROR_METHOD + request.getHttpServletRequest().getMethod()));
 		sectionInFields.add(markdownText(ERROR_DATE + formatDate(LocalDateTime.now())));
 		layoutBlockList.add(section(section -> section.fields(sectionInFields)));
 

--- a/src/main/java/com/mjuAppSW/joA/slack/vo/HttpServletRequestVO.java
+++ b/src/main/java/com/mjuAppSW/joA/slack/vo/HttpServletRequestVO.java
@@ -1,0 +1,13 @@
+package com.mjuAppSW.joA.slack.vo;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.Getter;
+
+@Getter
+public class HttpServletRequestVO {
+	private HttpServletRequest httpServletRequest;
+
+	public HttpServletRequestVO(HttpServletRequest httpServletRequest) {
+		this.httpServletRequest = httpServletRequest;
+	}
+}


### PR DESCRIPTION
# 요약
- 기존 Slack 알림 발송을 동기에서 비동기로 수정하였습니다.
- 메시지 신고 시 신고 내역 저장을 하지 않아, 수정하였습니다.
- Message Package 내부에 VO 패키지의 위치가 잘못되어 있어 수정하였습니다.
- 채팅방 목록 페이지 조회에서 @GetMapping URL 형식을 @PathVariable -> @RequestParam으로 변경하였습니다.

# 체크 리스트
이 PR에는:

- [ ] 새로운 테스트의 추가 여부
- [x] 공개 API의 변경 여부
- [ ] 설계 문서의 포함 여부

# 본문
Slack 알림 발송을 비동기로 수정하던 중 아래와 같은 에러를 발견하였습니다.

![스크린샷 2024-02-25 234608](https://github.com/hongkikii/JoA-2023-2/assets/61353820/79aa79f1-0824-4112-8d43-3a59e3878a24)

알림을 보낼 때 클라이언트가 서버에 보낸 HTTP 요청의 정보들을 담고있는 HttpServletRequest를 사용하는데, 
비동기 메소드가 실행되기 전 요청받은 스레드가 종료될 시 위 사진과 같은 에러가 발생합니다.

이를 방지하기 위해 HttpServletRequest를 VO에 담아 스레드가 종료되어도 사용할 수 있게 하였습니다. 

또한 QueueCapacity를 초과하는 비동기 메소드가 호출 시 TaskRejectedException이 발생하는데, catch를 통해 exception 처리를 하였습니다.