### PR TITLE
채팅 중 상대방 탈퇴여부 검증 로직 수정 및 Constant값 수정

### DIFF
--- a/src/main/java/com/mjuAppSW/joA/common/constant/Constants.java
+++ b/src/main/java/com/mjuAppSW/joA/common/constant/Constants.java
@@ -62,9 +62,9 @@ public class Constants {
         public static String EQUAL_OPERATION = "=";
         public static String ALARM_REPORTED_ROOM = "신고된 채팅방입니다.";
         public static String ALARM_OPPONENT_EXITED = "상대방이 채팅방을 나갔습니다.";
-        public static String ALARM_OPPONENT_IS_WITH_DRAWAL = "상대방이 joA앱을 탈퇴하였습니다.";
-        public static String ALARM_OVER_ONE_DAY = "방 유효시간이 24시간을 초과하였습니다.";
-        public static String ALARM_OVER_SEVEN_DAY = "방 유효시간이 7일을 초과하였습니다.";
+        public static String ALARM_OPPONENT_IS_WITH_DRAWAL = "상대방이 JoA를 탈퇴하였습니다.";
+        public static String ALARM_OVER_ONE_DAY = "채팅방 유효기간이 24시간을 초과하였습니다.";
+        public static String ALARM_OVER_SEVEN_DAY = "채팅방 유효기간이 7일을 초과하였습니다.";
         public static Integer MAX_CAPACITY_IN_ROOM = 2;
     }
 

--- a/src/main/java/com/mjuAppSW/joA/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/member/service/MemberQueryService.java
@@ -84,4 +84,8 @@ public class MemberQueryService {
             throw new PermanentBanException();
         }
     }
+
+    public Boolean validateIsWithDrawal(Long id){
+        return memberRepository.findById(id).isPresent();
+    }
 }

--- a/src/main/java/com/mjuAppSW/joA/domain/roomInMember/service/RoomInMemberService.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/roomInMember/service/RoomInMemberService.java
@@ -194,11 +194,9 @@ public class RoomInMemberService {
     public Boolean checkIsWithDrawal(Long roomId, Long memberId){
 		Room room = roomQueryService.getById(roomId);
         Member member = memberQueryService.getById(memberId);
-		RoomInMember rim = roomInMemberQueryService.getOpponentByRoomAndMember(room, member);
+		RoomInMember opponent = roomInMemberQueryService.getOpponentByRoomAndMember(room, member);
 
-        Member opponentMember = memberQueryService.getById(rim.getMember().getId());
-        if (opponentMember != null) return true;
-        return false;
+        return memberQueryService.validateIsWithDrawal(opponent.getMember().getId());
     }
 
     private String decrypt(String cipherText, String encryptionKey){


### PR DESCRIPTION
# 요약
- 채팅 중 상대방 탈퇴 검증 로직을 수정하였습니다.
- 채팅에 사용되는 Constant를 프론트 팀원의 피드백을 받고 수정하였습니다.

# 체크 리스트
이 PR에는:

- [ ] 새로운 테스트의 추가 여부
- [ ] 공개 API의 변경 여부
- [ ] 설계 문서의 포함 여부