### PR TITLE
최대 스레드 수 조정

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -44,4 +44,4 @@ slack:
 
 server:
   tomcat:
-    max-threads: 600
+    max-threads: 1200


### PR DESCRIPTION
# 요약
- tomcat의 최대 스레드 수를 조정하였습니다.

# 체크 리스트
이 PR에는:

- [ ] 새로운 테스트의 추가 여부
- [ ] 공개 API의 변경 여부
- [ ] 설계 문서의 포함 여부

# 본문
1초당 500건씩 60초간 API GET 정상 조회를 진행했을 때,
약 7000건의 타임아웃이 발생하지만 여전히 CPU 사용률은 15~20% 사이라 스레드 수를 600에서 1200으로 늘려보았습니다.