### PR TITLE
슬랙 원하는 알림 구분 및 알림 비동기로 변경

### DIFF
--- a/src/main/java/com/mjuAppSW/joA/common/constant/Constants.java
+++ b/src/main/java/com/mjuAppSW/joA/common/constant/Constants.java
@@ -83,7 +83,7 @@ public class Constants {
     public static class SlackServiceUtil{
         public static final String ERROR_MESSAGE = "*Error Message:*\n";
         public static final String ERROR_STACK = "*Error Stack:*\n";
-        public static final String ERROR_URI = "*Error URI:*\n";
+        public static final String ERROR_URL = "*Error URL:*\n";
         public static final String ERROR_METHOD = "*Error Method:*\n";
         public static final String ERROR_DATE = "*Error Date:*\n";
         public static final String FILTER_STRING = "joA";

--- a/src/main/java/com/mjuAppSW/joA/common/exception/ErrorCode.java
+++ b/src/main/java/com/mjuAppSW/joA/common/exception/ErrorCode.java
@@ -8,78 +8,79 @@ import lombok.RequiredArgsConstructor;
 public enum ErrorCode {
 
     // Common
-    INTERNAL_SERVER_ERROR(500, "C001", "서버에 오류가 발생하였습니다."),
+    INTERNAL_SERVER_ERROR(500, "C001", "서버에 오류가 발생하였습니다.", true),
 
     // Block
-    BLOCK_ACCESS_FORBIDDEN(403, "B001", "차단 조치에 의해 접근 권한이 없습니다."),
-    BLOCK_ALREADY_EXISTED(409, "B002", "이미 차단한 사용자입니다."),
+    BLOCK_ACCESS_FORBIDDEN(403, "B001", "차단 조치에 의해 접근 권한이 없습니다.", false),
+    BLOCK_ALREADY_EXISTED(409, "B002", "이미 차단한 사용자입니다.", false),
 
     // Heart
-    HEART_ALREADY_EXISTED(409, "H001", "이미 하트가 존재합니다."),
+    HEART_ALREADY_EXISTED(409, "H001", "이미 하트가 존재합니다.", false),
 
     // Location
-    LOCATION_NOT_FOUND(404, "L001", "사용자의 위치 정보를 찾을 수 없습니다."),
+    LOCATION_NOT_FOUND(404, "L001", "사용자의 위치 정보를 찾을 수 없습니다.", false),
 
     // Member
-    MEMBER_NOT_FOUND(404,"M001","사용자를 찾을 수 없습니다."),
-    ACCESS_FORBIDDEN(403, "M002", "접근 권한이 없는 계정입니다."), // 미사용
-    INVALID_S3(500, "M003", "S3 저장소 접근에 실패했습니다."),
-    ACCESS_STOPPED(403, "M004", "정지된 계정입니다."),
-    MEMBER_ALREADY_EXISTED(409, "M005", "이미 존재하는 사용자입니다."),
-    JOINING_MAIL(409, "M006", "회원가입 중인 이메일입니다."), // 미사용
-    SESSION_NOT_FOUND(404, "M007", "세션 id가 유효하지 않습니다."),
-    MAIL_NOT_VERIFY(400, "M008", "이메일 인증이 완료되지 않았습니다."),
-    INVALID_CERTIFY_NUMBER(400, "M009", "인증번호가 올바르지 않습니다."),
-    INVALID_LOGIN_ID(400, "M010", "올바른 아이디 형식이 아닙니다."),
-    LOGIN_ID_ALREADY_EXISTED(409, "M011", "이미 사용 중인 아이디입니다."),
-    INVALID_PASSWORD(400, "M012", "올바른 비밀번호 형식이 아닙니다."),
-    LOGIN_ID_NOT_AUTHORIZED(404, "M013", "아이디 중복 확인이 완료되지 않았습니다."),
-    PERMANENT_BAN(403, "M014", "영구 정지된 계정입니다."),
-    PASSWORD_NOT_FOUND(404, "M015", "비밀번호가 올바르지 않습니다."),
+    MEMBER_NOT_FOUND(404,"M001","사용자를 찾을 수 없습니다.", false),
+    ACCESS_FORBIDDEN(403, "M002", "접근 권한이 없는 계정입니다.", false), // 미사용
+    INVALID_S3(500, "M003", "S3 저장소 접근에 실패했습니다.", false),
+    ACCESS_STOPPED(403, "M004", "정지된 계정입니다.", false),
+    MEMBER_ALREADY_EXISTED(409, "M005", "이미 존재하는 사용자입니다.", false),
+    JOINING_MAIL(409, "M006", "회원가입 중인 이메일입니다.", false), // 미사용
+    SESSION_NOT_FOUND(404, "M007", "세션 id가 유효하지 않습니다.", false),
+    MAIL_NOT_VERIFY(400, "M008", "이메일 인증이 완료되지 않았습니다.", false),
+    INVALID_CERTIFY_NUMBER(400, "M009", "인증번호가 올바르지 않습니다.", false),
+    INVALID_LOGIN_ID(400, "M010", "올바른 아이디 형식이 아닙니다.", false),
+    LOGIN_ID_ALREADY_EXISTED(409, "M011", "이미 사용 중인 아이디입니다.", false),
+    INVALID_PASSWORD(400, "M012", "올바른 비밀번호 형식이 아닙니다.", false),
+    LOGIN_ID_NOT_AUTHORIZED(404, "M013", "아이디 중복 확인이 완료되지 않았습니다.", false),
+    PERMANENT_BAN(403, "M014", "영구 정지된 계정입니다.", false),
+    PASSWORD_NOT_FOUND(404, "M015", "비밀번호가 올바르지 않습니다.", false),
 
     // PCollege
-    COLLEGE_NOT_FOUND(404,"P001" , "학교 정보를 찾을 수 없습니다."),
-    OUT_OF_COLLEGE(409, "P002", "사용자가 학교 밖에 위치합니다."),
+    COLLEGE_NOT_FOUND(404,"P001" , "학교 정보를 찾을 수 없습니다.", false),
+    OUT_OF_COLLEGE(409, "P002", "사용자가 학교 밖에 위치합니다.", false),
 
     // Report Category
-    REPORT_CATEGORY_NOT_FOUND(404, "RC001", "신고 카테고리가 존재하지 않습니다."),
+    REPORT_CATEGORY_NOT_FOUND(404, "RC001", "신고 카테고리가 존재하지 않습니다.", false),
 
     // Vote
-    VOTE_NOT_FOUND(404, "V001", "투표가 존재하지 않습니다."),
-    VOTE_CATEGORY_NOT_FOUND(404, "V002", "투표 카테고리가 존재하지 않습니다."),
-    VOTE_ALREADY_EXISTED(409, "V003", "이미 투표가 존재합니다."),
-    INVALID_VOTE_EXISTED(403, "V004", "투표 신고로 인해 접근이 제한된 계정입니다."),
+    VOTE_NOT_FOUND(404, "V001", "투표가 존재하지 않습니다.", false),
+    VOTE_CATEGORY_NOT_FOUND(404, "V002", "투표 카테고리가 존재하지 않습니다.", false),
+    VOTE_ALREADY_EXISTED(409, "V003", "이미 투표가 존재합니다.", false),
+    INVALID_VOTE_EXISTED(403, "V004", "투표 신고로 인해 접근이 제한된 계정입니다.", false),
 
     // Vote Report
-    VOTE_REPORT_ALREADY_EXISTED(409, "VR001", "이미 투표 신고가 존재합니다."),
+    VOTE_REPORT_ALREADY_EXISTED(409, "VR001", "이미 투표 신고가 존재합니다.", false),
 
     // Room
-    ROOM_EXISTED(409, "R001", "이미 채팅방이 존재합니다."),
-    OVER_ONE_DAY(400, "R002", "채팅방이 생성된지 24시간이 지났습니다."),
-    ROOM_NOT_FOUND(404, "R003", "채팅방을 찾을 수 없습니다."),
-    ROOM_ALREADY_EXTEND(409, "R004", "이미 연장된 채팅방입니다."),
+    ROOM_EXISTED(409, "R001", "이미 채팅방이 존재합니다.", false),
+    OVER_ONE_DAY(400, "R002", "채팅방이 생성된지 24시간이 지났습니다.", false),
+    ROOM_NOT_FOUND(404, "R003", "채팅방을 찾을 수 없습니다.", true),
+    ROOM_ALREADY_EXTEND(409, "R004", "이미 연장된 채팅방입니다.", false),
 
     // RoomInMember
-    RIM_NOT_FOUND(404, "RIM001", "사용자와 연결된 채팅방을 찾을 수 없습니다."),
-    RIM_ALREADY_EXISTED(409, "RIM002", "이미 두 사용자의 채팅방이 존재합니다."),
-    RIM_ALREADY_VOTE_RESULT(409, "RIM003", "이미 채팅방 연장에 대한 투표가 존재합니다."),
+    RIM_NOT_FOUND(404, "RIM001", "사용자와 연결된 채팅방을 찾을 수 없습니다.", true),
+    RIM_ALREADY_EXISTED(409, "RIM002", "이미 두 사용자의 채팅방이 존재합니다.", false),
+    RIM_ALREADY_VOTE_RESULT(409, "RIM003", "이미 채팅방 연장에 대한 투표가 존재합니다.", false),
 
     // MessageReport
-    MESSAGE_REPORT_ALREADY_EXISTED(409, "MR001", "이미 신고된 메시지가 존재합니다."),
-    MESSAGE_REPORT_NOT_FOUND(404, "MR002", "신고된 메시지를 찾을 수 없습니다."),
-    MESSAGE_REPORT_ALREADY_REPORT(409, "MR003", "상대방을 신고한 메시지가 존재합니다."),
-    MESSAGE_REPORT_ALREADY_REPORTED(409, "MR004", "상대방에게 신고된 메시지가 존재합니다."),
+    MESSAGE_REPORT_ALREADY_EXISTED(409, "MR001", "이미 신고된 메시지가 존재합니다.", false),
+    MESSAGE_REPORT_NOT_FOUND(404, "MR002", "신고된 메시지를 찾을 수 없습니다.", true),
+    MESSAGE_REPORT_ALREADY_REPORT(409, "MR003", "상대방을 신고한 메시지가 존재합니다.", false),
+    MESSAGE_REPORT_ALREADY_REPORTED(409, "MR004", "상대방에게 신고된 메시지가 존재합니다.", false),
 
     // Message
-    MESSAGE_NOT_FOUND(404, "MG001", "메시지를 찾을 수 없습니다."),
-    FAIL_ENCRYPT(500, "MG002", "메시지 암호화를 실패했습니다."),
-    FAIL_DECRYPT(500, "MG003", "메시지 복호화를 실패했습니다."),
+    MESSAGE_NOT_FOUND(404, "MG001", "메시지를 찾을 수 없습니다.", true),
+    FAIL_ENCRYPT(500, "MG002", "메시지 암호화를 실패했습니다.", true),
+    FAIL_DECRYPT(500, "MG003", "메시지 복호화를 실패했습니다.", true),
 
     // WebSocket
-    ROOM_SESSION_LIST_IS_NULL(400, "W001", "방 섹션 리스트가 Null 입니다."),
-    MEMBER_SESSION_LIST_IS_NULL(400, "W002", "사용자 섹션 리스트가 Null 입니다.");
+    ROOM_SESSION_LIST_IS_NULL(400, "W001", "방 섹션 리스트가 Null 입니다.", true),
+    MEMBER_SESSION_LIST_IS_NULL(400, "W002", "사용자 섹션 리스트가 Null 입니다.", true);
 
     private final int status;
     private final String code;
     private final String message;
+    private final boolean alarm;
 }

--- a/src/main/java/com/mjuAppSW/joA/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/mjuAppSW/joA/common/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.mjuAppSW.joA.common.exception;
 
 import com.mjuAppSW.joA.common.dto.ErrorResponse;
+import com.mjuAppSW.joA.slack.vo.HttpServletRequestVO;
 import com.mjuAppSW.joA.slack.SlackService;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -21,20 +22,26 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<?> handleBusinessException(HttpServletRequest request, BusinessException e) {
+        HttpServletRequestVO httpServletRequestVO = new HttpServletRequestVO(request);
         ErrorCode errorCode = e.getErrorCode();
         if (errorCode.getStatus() == HttpStatus.INTERNAL_SERVER_ERROR.value()) {
             log.error("handleBusinessException", e);
         } else {
             log.warn("handleBusinessException", e);
         }
-        slackService.sendSlackMessageProductError(request, e);
+
+        if(errorCode.isAlarm()){
+            slackService.sendSlackMessageProductError(httpServletRequestVO, e);
+        }
+
         return makeErrorResponse(errorCode);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<?> handleException(HttpServletRequest request, Exception e) {
+        HttpServletRequestVO httpServletRequestVO = new HttpServletRequestVO(request);
         log.error("handleException", e);
-        slackService.sendSlackMessageProductError(request, e);
+        slackService.sendSlackMessageProductError(httpServletRequestVO, e);
         return makeErrorResponse(ErrorCode.INTERNAL_SERVER_ERROR);
     }
 

--- a/src/main/java/com/mjuAppSW/joA/slack/SlackService.java
+++ b/src/main/java/com/mjuAppSW/joA/slack/SlackService.java
@@ -7,14 +7,15 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.task.TaskRejectedException;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
+import com.mjuAppSW.joA.slack.vo.HttpServletRequestVO;
 import com.slack.api.Slack;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.model.Attachment;
 import com.slack.api.model.block.LayoutBlock;
 
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 
 @Service
@@ -25,9 +26,10 @@ public class SlackService {
 	@Value(value = "${slack.channel.monitor}")
 	String channelName;
 
-	public void sendSlackMessageProductError(HttpServletRequest httpServletRequest, Exception exception) {
+	@Async
+	public void sendSlackMessageProductError(HttpServletRequestVO httpServletRequestVO, Exception exception) {
 		try {
-			List<LayoutBlock> layoutBlocks = SlackServiceUtil.createProdErrorMessage(httpServletRequest, exception);
+			List<LayoutBlock> layoutBlocks = SlackServiceUtil.createProdErrorMessage(httpServletRequestVO, exception);
 			List<Attachment> attachments = SlackServiceUtil.createAttachments(ERROR_COLOR,
 				layoutBlocks);
 			Slack.getInstance().methods(token).chatPostMessage(request ->

--- a/src/main/java/com/mjuAppSW/joA/slack/SlackServiceUtil.java
+++ b/src/main/java/com/mjuAppSW/joA/slack/SlackServiceUtil.java
@@ -9,11 +9,10 @@ import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.mjuAppSW.joA.slack.vo.HttpServletRequestVO;
 import com.slack.api.model.Attachment;
 import com.slack.api.model.block.LayoutBlock;
 import com.slack.api.model.block.composition.TextObject;
-
-import jakarta.servlet.http.HttpServletRequest;
 
 public class SlackServiceUtil {
 
@@ -26,7 +25,7 @@ public class SlackServiceUtil {
 		return attachments;
 	}
 
-	public static List<LayoutBlock> createProdErrorMessage(HttpServletRequest request, Exception exception) {
+	public static List<LayoutBlock> createProdErrorMessage(HttpServletRequestVO request, Exception exception) {
 		StackTraceElement[] stacks = exception.getStackTrace();
 
 		List<LayoutBlock> layoutBlockList = new ArrayList<>();
@@ -34,7 +33,7 @@ public class SlackServiceUtil {
 		List<TextObject> sectionInFields = new ArrayList<>();
 		sectionInFields.add(markdownText(ERROR_MESSAGE + exception.getMessage()));
 		sectionInFields.add(markdownText(ERROR_STACK + exception));
-		sectionInFields.add(markdownText(ERROR_URI + request.getRequestURL()));
+		sectionInFields.add(markdownText(ERROR_URL + request.getRequestURL()));
 		sectionInFields.add(markdownText(ERROR_METHOD + request.getMethod()));
 		sectionInFields.add(markdownText(ERROR_DATE + formatDate(LocalDateTime.now())));
 		layoutBlockList.add(section(section -> section.fields(sectionInFields)));

--- a/src/main/java/com/mjuAppSW/joA/slack/vo/HttpServletRequestVO.java
+++ b/src/main/java/com/mjuAppSW/joA/slack/vo/HttpServletRequestVO.java
@@ -1,0 +1,15 @@
+package com.mjuAppSW.joA.slack.vo;
+
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.Getter;
+
+@Getter
+public class HttpServletRequestVO {
+	private String requestURL;
+	private String method;
+
+	public HttpServletRequestVO(HttpServletRequest request){
+		this.requestURL = String.valueOf(request.getRequestURL());
+		this.method = request.getMethod();
+	}
+}


### PR DESCRIPTION
# 요약
- 모든 Exception에 대해 알림 발송을 원하는 Exception에 대해 알림을 발송할 수 있게 수정하였습니다.
- 슬랙 알림을 동기에서 비동기로 수정하였습니다.
- Slack Constant의 값을 URI에서 URL로 수정하였습니다.

# 체크 리스트
이 PR에는:

- [ ] 새로운 테스트의 추가 여부
- [ ] 공개 API의 변경 여부
- [ ] 설계 문서의 포함 여부

# 본문
ErrorCode에 boolean 값으로 구분점을 두어 true인 경우에만 Slack 알림을 발송하게 하였습니다.
알림 발송 방법을 동기에서 비동기로 변경하면서 평균 250ms -> 20ms로 지연시간이 절감되었습니다.