### PR TITLE
커넥션풀 크기 조정

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -2,9 +2,9 @@ spring:
   datasource:
     hikari:
       primary:
-        maximum-pool-size: 500
+        maximum-pool-size: 1200
       secondary:
-        maximum-pool-size: 500
+        maximum-pool-size: 1200
     primary:
       driver-class-name: com.mysql.cj.jdbc.Driver
       jdbc-url: ${AWS_MYSQL_URL}


### PR DESCRIPTION
# 요약
- API GET 정상 조회 기준으로, 60초간 초당 450개를 초과하는 요청이 갔을 때 에러율이 급격히 높아져 커넥션풀 크기를 500 -> 1200으로 조정해보았습니다.

# 체크 리스트
이 PR에는:

- [ ] 새로운 테스트의 추가 여부
- [ ] 공개 API의 변경 여부
- [ ] 설계 문서의 포함 여부
