### PR TITLE
동일 차단 존재 유무 확인 쿼리 락 설정

### DIFF
--- a/src/main/java/com/mjuAppSW/joA/geography/block/repository/BlockJpaRepository.java
+++ b/src/main/java/com/mjuAppSW/joA/geography/block/repository/BlockJpaRepository.java
@@ -1,14 +1,17 @@
 package com.mjuAppSW.joA.geography.block.repository;
 
 import com.mjuAppSW.joA.geography.block.entity.Block;
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface BlockJpaRepository extends JpaRepository<Block, Long> {
 
+    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT b FROM Block b WHERE b.blocker.id = :blockerId AND b.blocked.id = :blockedId")
     Optional<Block> findEqualBy(@Param("blockerId") Long blockerId, @Param("blockedId") Long blockedId);
 


### PR DESCRIPTION
# 요약
- (성능 테스트 도중 시범적으로) 동일한 차단이 이미 존재하는지 확인하는 쿼리에 락을 설정해보았습니다.

# 체크 리스트
이 PR에는:

- [ ] 새로운 테스트의 추가 여부
- [ ] 공개 API의 변경 여부
- [ ] 설계 문서의 포함 여부

# 본문
성능 테스트에서 동일한 차단 요청을 동시에 여러개 보내는 시나리오를 진행했습니다.
이 차단 요청 API에서는 우선적으로 이미 동일한 차단이 존재하는지를 체크합니다.
즉, 코드 논리상 동일한 차단은 하나밖에 저장될 수 없는 구조인 것이죠.
하지만 이 체크 로직에서 사용되는 쿼리 값이 unique 하지 않아 예외가 발생하는 상황이 생겼습니다!

저는 이것이 동시성 문제 때문에 발생한 상황이라 판단하였고, 쿼리에 락을 걸어 다시 테스트를 진행해보려 합니다.