### PR TITLE
차단 API 서비스 계층 @Transactional 제거

### DIFF
--- a/src/main/java/com/mjuAppSW/joA/geography/block/repository/BlockJpaRepository.java
+++ b/src/main/java/com/mjuAppSW/joA/geography/block/repository/BlockJpaRepository.java
@@ -11,7 +11,6 @@ import org.springframework.data.repository.query.Param;
 
 public interface BlockJpaRepository extends JpaRepository<Block, Long> {
 
-    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT b FROM Block b WHERE b.blocker.id = :blockerId AND b.blocked.id = :blockedId")
     Optional<Block> findEqualBy(@Param("blockerId") Long blockerId, @Param("blockedId") Long blockedId);
 

--- a/src/main/java/com/mjuAppSW/joA/geography/block/service/BlockService.java
+++ b/src/main/java/com/mjuAppSW/joA/geography/block/service/BlockService.java
@@ -22,7 +22,6 @@ public class BlockService {
     private final MemberQueryService memberQueryService;
     private final BlockQueryService blockQueryService;
 
-    @Transactional
     public void execute(BlockRequest request) {
         Member blockerMember = memberQueryService.getBySessionId(request.getBlockerId());
         Member blockedMember = memberQueryService.getById(request.getBlockedId());


### PR DESCRIPTION
# 요약
(성능 테스트 도중)
- 트랜잭션이 리포지토리 수준에서만 걸렸을 때의 상황을 확인하고자 서비스 계층의 @Transactional을 제거하였습니다.
- 조회 메소드에 락을 걸 필요가 없다고 생각해 락을 제거하였습니다.

# 체크 리스트
이 PR에는:

- [ ] 새로운 테스트의 추가 여부
- [ ] 공개 API의 변경 여부
- [ ] 설계 문서의 포함 여부
