### PR TITLE
로그인, 로그아웃 API 서비스 계층 @Transactional 제거

### DIFF
--- a/src/main/java/com/mjuAppSW/joA/domain/member/service/AccountService.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/member/service/AccountService.java
@@ -28,7 +28,6 @@ public class AccountService {
     private final MailSender mailSender;
     private final PasswordManager passwordManager;
 
-    @Transactional
     public SessionIdResponse login(LoginRequest request) {
         Member member = memberQueryService.getByLoginId(request.getLoginId());
         String hashedPassword = passwordManager.createHashed (
@@ -38,7 +37,6 @@ public class AccountService {
         return SessionIdResponse.of(member.getSessionId());
     }
 
-    @Transactional
     public void logout(Long sessionId) {
         Member member = memberQueryService.getBySessionId(sessionId);
         member.expireSessionId();


### PR DESCRIPTION
# 요약
- 성능 테스트 도중 POST 요청의 성능 저하 현상 원인을 파악하기 위해 로그인, 로그아웃 API의 서비스 계층에서 트랜잭선을 삭제해보았습니다.

# 체크 리스트
이 PR에는:

- [ ] 새로운 테스트의 추가 여부
- [ ] 공개 API의 변경 여부
- [ ] 설계 문서의 포함 여부
