### PR TITLE
커스텀 예외 빈 stackTrace 반환

### DIFF
--- a/src/main/java/com/mjuAppSW/joA/common/exception/BusinessException.java
+++ b/src/main/java/com/mjuAppSW/joA/common/exception/BusinessException.java
@@ -11,4 +11,9 @@ public class BusinessException extends RuntimeException {
         super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
+
+    @Override
+    public synchronized Throwable fillInStackTrace() {
+        return this;
+    }
 }


### PR DESCRIPTION
# 요약
- 성능 테스트 중 예외가 발생할 때 지연이 생기는 것을 해결하기 위해 stackTrace 비용을 줄여보았습니다.
- 커스텀 예외가 에러 추적 보다는 비즈니스 로직을 막는 용도라 커스텀 예외에 적용해보았습니다.

# 체크 리스트
이 PR에는:

- [ ] 새로운 테스트의 추가 여부
- [ ] 공개 API의 변경 여부
- [ ] 설계 문서의 포함 여부