### PR TITLE
FCM 전송 방법 수정

### DIFF
--- a/src/main/java/com/mjuAppSW/joA/common/config/FirebaseConfig.java
+++ b/src/main/java/com/mjuAppSW/joA/common/config/FirebaseConfig.java
@@ -15,6 +15,10 @@ import org.springframework.core.io.ClassPathResource;
 public class FirebaseConfig {
     @Value(value = "${fcm.json.path}")
     private String jsonPath;
+
+    @Value(value = "${fcm.project-id}")
+    private String projectId;
+
     private ClassPathResource firebaseResource;
 
     @PostConstruct
@@ -26,6 +30,7 @@ public class FirebaseConfig {
     FirebaseApp firebaseApp() throws IOException{
         FirebaseOptions options = FirebaseOptions.builder()
             .setCredentials(GoogleCredentials.fromStream(firebaseResource.getInputStream()))
+            .setProjectId(projectId)
             .build();
         return FirebaseApp.initializeApp(options);
     }

--- a/src/main/java/com/mjuAppSW/joA/domain/member/entity/Member.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/member/entity/Member.java
@@ -98,6 +98,10 @@ public class Member {
         this.sessionId = null;
     }
 
+    public void expireFcmToken(){
+        this.fcmToken = null;
+    }
+
     public void updatePassword(String password) {
         this.password = password;
     }

--- a/src/main/java/com/mjuAppSW/joA/domain/member/service/AccountService.java
+++ b/src/main/java/com/mjuAppSW/joA/domain/member/service/AccountService.java
@@ -44,6 +44,7 @@ public class AccountService {
     public void logout(Long sessionId) {
         Member member = memberQueryService.getBySessionId(sessionId);
         member.expireSessionId();
+        member.expireFcmToken();
     }
 
     public void findLoginId(String collegeEmail, Long collegeId) {

--- a/src/main/java/com/mjuAppSW/joA/fcm/service/FCMService.java
+++ b/src/main/java/com/mjuAppSW/joA/fcm/service/FCMService.java
@@ -1,84 +1,55 @@
 package com.mjuAppSW.joA.fcm.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.google.auth.oauth2.GoogleCredentials;
-import com.google.common.net.HttpHeaders;
 import com.google.firebase.messaging.ApnsConfig;
 import com.google.firebase.messaging.Aps;
+import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
 import com.mjuAppSW.joA.fcm.vo.FCMInfoVO;
-import com.mjuAppSW.joA.fcm.vo.FCMMessageVO;
-import java.io.IOException;
-import java.util.Arrays;
+import java.util.concurrent.ExecutionException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
-import org.springframework.core.io.ClassPathResource;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.beans.factory.annotation.Value;
 
 @RequiredArgsConstructor
 @Slf4j
 @Service
 public class FCMService {
-    @Value(value = "${fcm.url}")
-    private String url;
-
-    @Value(value = "${fcm.json.path}")
-    private String jsonPath;
-
-    private final ObjectMapper objectMapper;
+    private final FirebaseMessaging firebaseMessaging;
 
     @Async
-    public void send(FCMInfoVO vo) {
-        try {
-            String message = make(vo);
-            OkHttpClient client = new OkHttpClient();
-            RequestBody requestBody = RequestBody.create(message, MediaType.get("application/json; charset=utf-8"));
-            Request request = new Request.Builder()
-                .url(url)
-                .post(requestBody)
-                .addHeader(HttpHeaders.AUTHORIZATION, "Bearer " + getAccessToken())
-                .addHeader(HttpHeaders.CONTENT_TYPE, "application/json; UTF-8")
-                .build();
-            Response response = client.newCall(request).execute();
-            log.info(response.body().string());
-        } catch (IOException e) {
-            throw new RuntimeException(e);
+    public void send(FCMInfoVO vo){
+        try{
+            Message message = make(vo);
+            String response = firebaseMessaging.sendAsync(message).get();
+            log.info("Send FCM Notification targetMember = {}, response = {}", vo.getTargetMember().getId(), response);
+        }catch (InterruptedException | ExecutionException e) {
+            log.error(e.getMessage(), e);
         }
     }
 
-    public String make(FCMInfoVO vo) throws JsonProcessingException {
-        FCMMessageVO fcmMessageVO = FCMMessageVO.builder()
-            .message(Message.builder()
-                .setToken(vo.getTargetMember().getFcmToken())
-                .setNotification(Notification.builder()
-                    .setTitle(vo.getMemberName() + " " + vo.getConstants().getTitle())
-                    .setBody(vo.getConstants().getBody() + vo.getContent())
-                    .build())
-                .setApnsConfig(ApnsConfig.builder()
+    public Message make(FCMInfoVO vo){
+        log.info(vo.getTargetMember().getFcmToken());
+        log.info("title = {}, body = {}", vo.getConstants().getTitle(), vo.getConstants().getBody());
+        log.info(vo.getMemberName());
+        log.info(vo.getContent());
+        Notification notification = Notification.builder()
+            .setTitle(vo.getMemberName() + " " + vo.getConstants().getTitle())
+            .setBody(vo.getConstants().getBody())
+        .build();
+
+        Message message = Message.builder()
+            .setToken(vo.getTargetMember().getFcmToken())
+            .setNotification(notification)
+            .setApnsConfig(
+                ApnsConfig.builder()
                     .setAps(Aps.builder()
                         .setSound("default")
                         .build())
-                    .build())
                 .build())
-            .validateOnly(false)
-            .build();
-        return objectMapper.writeValueAsString(fcmMessageVO);
-    }
+        .build();
 
-    private String getAccessToken() throws IOException {
-        GoogleCredentials googleCredentials = GoogleCredentials
-            .fromStream(new ClassPathResource(jsonPath).getInputStream())
-            .createScoped(Arrays.asList("https://www.googleapis.com/auth/cloud-platform"));
-        googleCredentials.refreshIfExpired();
-        return googleCredentials.getAccessToken().getTokenValue();
+        return message;
     }
 }

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -54,6 +54,7 @@ slack:
 
 fcm:
   url: ${FCM_URL}
+  project-id: ${FCM_PROJECT_ID}
   json:
     path: ${FCM_JSON_PATH}
 


### PR DESCRIPTION
# 요약
- 기존의 방법은 직접 FCM에게 보내는 VO 값을 직접 생성하여 보냈으나, 직렬화 문제로 Firebase에서 제공하는 FirebaseMessaging를 이용하여 보내는 방법으로 수정하였습니다.
- 앱 로그아웃을 하면 fcmToken을 만료하는 로직을 추가했습니다.

- [ ] 새로운 테스트의 추가 여부
- [ ] 공개 API의 변경 여부
- [ ] 설계 문서의 포함 여부