### PR TITLE
FCM 전송 방법 변경

### DIFF
--- a/src/main/java/com/mjuAppSW/joA/fcm/service/FCMService.java
+++ b/src/main/java/com/mjuAppSW/joA/fcm/service/FCMService.java
@@ -57,7 +57,7 @@ public class FCMService {
             .message(FCMMessageVO.Message.builder()
                 .token(vo.getTargetMember().getFcmToken())
                 .notification(FCMMessageVO.Notification.builder()
-                    .title(vo.getConstants().getTitle())
+                    .title(vo.getMemberName() + " " + vo.getConstants().getTitle())
                     .body(vo.getConstants().getBody())
                     .build())
                 .build())

--- a/src/main/java/com/mjuAppSW/joA/fcm/vo/FCMMessageVO.java
+++ b/src/main/java/com/mjuAppSW/joA/fcm/vo/FCMMessageVO.java
@@ -15,6 +15,14 @@ public class FCMMessageVO {
     @Builder
     @AllArgsConstructor
     @Getter
+    public static class Message{
+        private Notification notification;
+        private String token;
+    }
+
+    @Builder
+    @AllArgsConstructor
+    @Getter
     public static class Notification{
         private String title;
         private String body;


### PR DESCRIPTION
# 요약
- Firebase에서 구현된 클래스를 사용하지 않고, 직접 fcm에게 전송하는 vo 객체를 만들었습니다.

# 체크 리스트
이 PR에는:

- [ ] 새로운 테스트의 추가 여부
- [ ] 공개 API의 변경 여부
- [ ] 설계 문서의 포함 여부
